### PR TITLE
3 feature 유저 회원가입로그인 기능 추가

### DIFF
--- a/src/main/java/dev/book/BookApplication.java
+++ b/src/main/java/dev/book/BookApplication.java
@@ -2,9 +2,7 @@ package dev.book;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class BookApplication {
     public static void main(String[] args) {

--- a/src/main/java/dev/book/global/config/jpa/JpaConfig.java
+++ b/src/main/java/dev/book/global/config/jpa/JpaConfig.java
@@ -1,0 +1,19 @@
+package dev.book.global.config.jpa;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return () -> Optional.of(SecurityContextHolder.getContext().getAuthentication().getName());
+    }
+}

--- a/src/main/java/dev/book/global/config/security/OAuth2AuthorizationRequestBasedOnCookieRepository.java
+++ b/src/main/java/dev/book/global/config/security/OAuth2AuthorizationRequestBasedOnCookieRepository.java
@@ -1,0 +1,61 @@
+package dev.book.global.config.security;
+
+import dev.book.global.config.security.util.CookieUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.web.util.WebUtils;
+
+/*
+ - OAuth2 로그인 진행 시
+ 외부 호출(kakao) 이후 redirect 될 때 AuthorizationRequest 내용을 기억하기 위하여
+ 쿠키에 저장하고 반환하는 로직
+ */
+
+public class OAuth2AuthorizationRequestBasedOnCookieRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+    public final static String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    private final static int COOKIE_EXPIRE_SECONDS = 18000;
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
+        return this.loadAuthorizationRequest(request);
+    }
+
+    /**
+     * OAuth2AuthorizationRequest 내용이 담긴 쿠키를 역직렬화하여 반환한다.
+     * @param request the {@code HttpServletRequest}
+     * @return
+     */
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        Cookie cookie = WebUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        return CookieUtil.deserialize(cookie, OAuth2AuthorizationRequest.class);
+    }
+
+    /**
+     * OAuth2AuthorizationRequest 내용을 직렬화하여 쿠키에 저장한다.
+     * @param authorizationRequest the {@link OAuth2AuthorizationRequest}
+     * @param request the {@code HttpServletRequest}
+     * @param response the {@code HttpServletResponse}
+     */
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            removeAuthorizationRequestCookies(request, response);
+            return;
+        }
+
+        CookieUtil.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtil.serialize(authorizationRequest), COOKIE_EXPIRE_SECONDS);
+    }
+
+    /**
+     * OAuth2AuthorizationRequest 내용이 담긴 쿠키를 삭제한다.
+     * @param request
+     * @param response
+     */
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+    }
+}

--- a/src/main/java/dev/book/global/config/security/SecurityConfig.java
+++ b/src/main/java/dev/book/global/config/security/SecurityConfig.java
@@ -1,0 +1,50 @@
+package dev.book.global.config.security;
+
+import dev.book.global.config.security.handler.OAuth2FailureHandler;
+import dev.book.global.config.security.handler.OAuth2SuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(CsrfConfigurer::disable)
+                .httpBasic(HttpBasicConfigurer::disable)
+                .formLogin(FormLoginConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(
+                        authorize -> authorize
+//                                .requestMatchers("/login").permitAll()
+                                .anyRequest().permitAll()
+                        //todo 현재는 모든 경로를 열어놓음 추후 endpoint마다 권한 설정
+                )
+                .oauth2Login(
+                        oauth2 -> oauth2
+                                .authorizationEndpoint(authorization ->
+                                        authorization.authorizationRequestRepository(OAuth2AuthorizationRequestBasedOnCookieRepository()))
+                                .successHandler(oAuth2SuccessHandler)
+                                .failureHandler(oAuth2FailureHandler)
+                );
+        return http.build();
+    }
+
+    @Bean
+    public OAuth2AuthorizationRequestBasedOnCookieRepository OAuth2AuthorizationRequestBasedOnCookieRepository(){
+        return new OAuth2AuthorizationRequestBasedOnCookieRepository();
+    }
+}

--- a/src/main/java/dev/book/global/config/security/dto/CustomOAuth2User.java
+++ b/src/main/java/dev/book/global/config/security/dto/CustomOAuth2User.java
@@ -1,0 +1,27 @@
+package dev.book.global.config.security.dto;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+public record CustomOAuth2User(String email, Map<String, Object> attributes) implements OAuth2User {
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getName() {
+        return email;
+    }
+}

--- a/src/main/java/dev/book/global/config/security/dto/OAuth2Attributes.java
+++ b/src/main/java/dev/book/global/config/security/dto/OAuth2Attributes.java
@@ -1,0 +1,26 @@
+package dev.book.global.config.security.dto;
+
+import lombok.Builder;
+
+import java.util.Map;
+
+public record OAuth2Attributes(String nickname, String email, String profileImageUrl) {
+
+    @Builder
+    public OAuth2Attributes {
+    }
+
+    public static OAuth2Attributes toKakao(Map<String, Object> attributes) {
+        Map<String, Object> kakao_account = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakao_account.get("profile");
+        String profileImageUrl = (String) profile.get("profile_image_url");
+        String nickname = (String) profile.get("nickname");
+        String email = (String) kakao_account.get("email");
+
+        return OAuth2Attributes.builder()
+                .email(email)
+                .nickname(nickname)
+                .profileImageUrl(profileImageUrl)
+                .build();
+    }
+}

--- a/src/main/java/dev/book/global/config/security/exception/CustomOAuth2Error.java
+++ b/src/main/java/dev/book/global/config/security/exception/CustomOAuth2Error.java
@@ -1,0 +1,15 @@
+package dev.book.global.config.security.exception;
+
+import lombok.Getter;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+@Getter
+public class CustomOAuth2Error extends OAuth2Error {
+
+    private final int httpCode;
+
+    public CustomOAuth2Error(String errorCode, String description, String uri, int httpCode) {
+        super(errorCode, description, uri);
+        this.httpCode = httpCode;
+    }
+}

--- a/src/main/java/dev/book/global/config/security/exception/UnValidatedProviderException.java
+++ b/src/main/java/dev/book/global/config/security/exception/UnValidatedProviderException.java
@@ -1,0 +1,15 @@
+package dev.book.global.config.security.exception;
+
+import lombok.Getter;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
+@Getter
+public class UnValidatedProviderException extends OAuth2AuthenticationException {
+
+    private final int httpCode;
+
+    public UnValidatedProviderException(CustomOAuth2Error oAuth2Error){
+        super(oAuth2Error);
+        this.httpCode = oAuth2Error.getHttpCode();
+    }
+}

--- a/src/main/java/dev/book/global/config/security/handler/OAuth2FailureHandler.java
+++ b/src/main/java/dev/book/global/config/security/handler/OAuth2FailureHandler.java
@@ -1,0 +1,24 @@
+package dev.book.global.config.security.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/*
+ OAuth2 로그인 실패 시
+ */
+@Component
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+
+        getRedirectStrategy().sendRedirect(request, response, "/login");
+    }
+}

--- a/src/main/java/dev/book/global/config/security/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/dev/book/global/config/security/handler/OAuth2SuccessHandler.java
@@ -1,0 +1,38 @@
+package dev.book.global.config.security.handler;
+
+import dev.book.global.config.security.service.Oauth2AuthService;
+import dev.book.user.enums.UserLoginState;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/*
+OAuth2 로그인 성공 시
+ */
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final Oauth2AuthService oauth2AuthService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+
+        //가져온 인증 정보를 통해 유저 존재 여부 확인 후 리다이렉션 진행
+        UserLoginState userLoginState = oauth2AuthService.getAttributes(authentication, response);
+
+        switch(userLoginState){ //todo 반환되는 화면 경로 정하기
+            case LOGIN_SUCCESS ->
+                getRedirectStrategy().sendRedirect(request, response, "/main");
+            case PROFILE_INCOMPLETE ->
+                getRedirectStrategy().sendRedirect(request, response, "/signup");
+        }
+    }
+}

--- a/src/main/java/dev/book/global/config/security/service/CustomOAuth2UserService.java
+++ b/src/main/java/dev/book/global/config/security/service/CustomOAuth2UserService.java
@@ -1,0 +1,36 @@
+package dev.book.global.config.security.service;
+
+import dev.book.global.config.security.dto.CustomOAuth2User;
+import dev.book.global.config.security.dto.OAuth2Attributes;
+import dev.book.global.config.security.exception.CustomOAuth2Error;
+import dev.book.global.config.security.exception.UnValidatedProviderException;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+/**
+ * OAuth2 로그인 결과를 CustomOAuth2User로 생성하여 SecurityContext에 등록한다.
+ */
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        String provider = userRequest.getClientRegistration().getRegistrationId();
+
+        if (provider.equals("kakao")){
+            OAuth2Attributes kakaoAttributes = OAuth2Attributes.toKakao(attributes);
+            return new CustomOAuth2User(kakaoAttributes.email(), attributes);
+        } else {
+            CustomOAuth2Error oAuth2Error = new CustomOAuth2Error("Invalid_Provider", "지원되지 않는 공급자입니다.", null, 403);
+            throw new UnValidatedProviderException(oAuth2Error);
+        }
+    }
+
+}

--- a/src/main/java/dev/book/global/config/security/service/Oauth2AuthService.java
+++ b/src/main/java/dev/book/global/config/security/service/Oauth2AuthService.java
@@ -1,10 +1,11 @@
 package dev.book.global.config.security.service;
 
+import dev.book.global.config.security.dto.OAuth2Attributes;
 import dev.book.global.config.security.exception.CustomOAuth2Error;
 import dev.book.global.config.security.exception.UnValidatedProviderException;
 import dev.book.user.entity.UserEntity;
 import dev.book.user.enums.UserLoginState;
-import dev.book.user.service.UserService;
+import dev.book.user.repository.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -13,17 +14,16 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
- * OAuth2User에서 필요한 정보를 가져온다.
- * - kakao
- *   profile_nickname, profile_image, account_email
+ * OAuth2User에서 attributes를 통해 유저의 상태 파악 후 UserLoginState 반환
  */
 @Service
 @RequiredArgsConstructor
 public class Oauth2AuthService {
 
-    private final UserService userService;
+    private final UserRepository userRepository;
 
     public UserLoginState getAttributes(Authentication authentication, HttpServletResponse response){
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
@@ -32,7 +32,8 @@ public class Oauth2AuthService {
         Map<String, Object> attributes = oAuth2User.getAttributes();
 
         if (provider.equals("kakao")){
-            return getKakaoAttributes(attributes);
+            OAuth2Attributes kakaoAttributes = OAuth2Attributes.toKakao(attributes);
+            return getUserLoginState(kakaoAttributes);
         } else {
             CustomOAuth2Error oAuth2Error = new CustomOAuth2Error("Invalid_Provider", "지원되지 않는 공급자입니다.", null, 403);
             throw new UnValidatedProviderException(oAuth2Error);
@@ -40,26 +41,26 @@ public class Oauth2AuthService {
     }
 
     /**
-     * attributes에서 필요한 정보들을 반환한다.
-     * @param attributes
-     * @return DB에서 유저를 조회하여 존재한다면 LOGIN_SUCCESS, 존재하지 않으면 현재 kakao 정보들만 저장한 후에 PROFILE_INCOMPLETE
+     * DB에서 유저를 조회하여 존재한다면 LOGIN_SUCCESS
+     * nickname이 비어 있거나 존재하지 않으면 현재 kakao 정보들만 저장한 후에 PROFILE_INCOMPLETE
+     * @param OAuth2Attributes
+     * @return
      */
-    private UserLoginState getKakaoAttributes(Map<String, Object> attributes) {
-        Map<String, Object> kakao_account = (Map<String, Object>) attributes.get("kakao_account");
-        Map<String, Object> profile = (Map<String, Object>) kakao_account.get("profile");
-        String profileImageUrl = (String) profile.get("profile_image_url");
-        String nickname = (String) profile.get("nickname");
-        String email = (String) kakao_account.get("email");
-
-        if (userService.isUserExist(email)) return UserLoginState.LOGIN_SUCCESS;
+    private UserLoginState getUserLoginState(OAuth2Attributes OAuth2Attributes) {
+        Optional<UserEntity> user = userRepository.findByEmail(OAuth2Attributes.email());
+        if (user.isPresent()){
+            if (user.get().getNickname().isBlank())
+                return UserLoginState.PROFILE_INCOMPLETE;
+            else return UserLoginState.LOGIN_SUCCESS;
+        }
         else {
             UserEntity newUser = UserEntity.builder()
-                    .email(email)
-                    .name(nickname)
+                    .email(OAuth2Attributes.email())
+                    .name(OAuth2Attributes.nickname())
                     .nickname("")
-                    .profileImageUrl(profileImageUrl)
+                    .profileImageUrl(OAuth2Attributes.profileImageUrl())
                     .build();
-            userService.unComplete(newUser);
+            userRepository.save(newUser);
             return UserLoginState.PROFILE_INCOMPLETE;
         }
     }

--- a/src/main/java/dev/book/global/config/security/service/Oauth2AuthService.java
+++ b/src/main/java/dev/book/global/config/security/service/Oauth2AuthService.java
@@ -1,0 +1,67 @@
+package dev.book.global.config.security.service;
+
+import dev.book.global.config.security.exception.CustomOAuth2Error;
+import dev.book.global.config.security.exception.UnValidatedProviderException;
+import dev.book.user.entity.UserEntity;
+import dev.book.user.enums.UserLoginState;
+import dev.book.user.service.UserService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+/**
+ * OAuth2User에서 필요한 정보를 가져온다.
+ * - kakao
+ *   profile_nickname, profile_image, account_email
+ */
+@Service
+@RequiredArgsConstructor
+public class Oauth2AuthService {
+
+    private final UserService userService;
+
+    public UserLoginState getAttributes(Authentication authentication, HttpServletResponse response){
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        String provider = ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId();
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        if (provider.equals("kakao")){
+            return getKakaoAttributes(attributes);
+        } else {
+            CustomOAuth2Error oAuth2Error = new CustomOAuth2Error("Invalid_Provider", "지원되지 않는 공급자입니다.", null, 403);
+            throw new UnValidatedProviderException(oAuth2Error);
+        }
+    }
+
+    /**
+     * attributes에서 필요한 정보들을 반환한다.
+     * @param attributes
+     * @return DB에서 유저를 조회하여 존재한다면 LOGIN_SUCCESS, 존재하지 않으면 현재 kakao 정보들만 저장한 후에 PROFILE_INCOMPLETE
+     */
+    private UserLoginState getKakaoAttributes(Map<String, Object> attributes) {
+        Map<String, Object> kakao_account = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakao_account.get("profile");
+        String profileImageUrl = (String) profile.get("profile_image_url");
+        String nickname = (String) profile.get("nickname");
+        String email = (String) kakao_account.get("email");
+
+        if (userService.isUserExist(email)) return UserLoginState.LOGIN_SUCCESS;
+        else {
+            UserEntity newUser = UserEntity.builder()
+                    .email(email)
+                    .name(nickname)
+                    .nickname("")
+                    .profileImageUrl(profileImageUrl)
+                    .build();
+            userService.unComplete(newUser);
+            return UserLoginState.PROFILE_INCOMPLETE;
+        }
+    }
+
+}

--- a/src/main/java/dev/book/global/config/security/util/CookieUtil.java
+++ b/src/main/java/dev/book/global/config/security/util/CookieUtil.java
@@ -1,0 +1,72 @@
+package dev.book.global.config.security.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.SerializationUtils;
+
+import java.io.Serializable;
+import java.util.Base64;
+
+public class CookieUtil {
+
+    /**
+     * 쿠키를 추가합니다.
+     * @param response
+     * @param name 쿠키 이름
+     * @param value 쿠키 값
+     * @param maxAge 유효 시간
+     */
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    /**
+     * 삭제할 쿠키의 유효 시간을 0으로 설정하여 삭제합니다.
+     * @param request
+     * @param response
+     * @param name 쿠키 이름
+     */
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null)
+            return;
+
+        for (Cookie cookie : cookies){
+            if (cookie.getName().equals(name)) {
+                cookie.setValue("");
+                cookie.setMaxAge(0);
+                response.addCookie(cookie);
+            }
+        }
+    }
+
+    /**
+     * 쿠키를 역직렬화하여 객체를 반환합니다.
+     * @param cookie
+     * @param tClass
+     * @return 역직렬화된 객체
+     * @param <T>
+     */
+    public static <T> T deserialize(Cookie cookie, Class<T> tClass) {
+        return tClass.cast(
+                SerializationUtils.deserialize(
+                        Base64.getUrlDecoder().decode(cookie.getValue())
+                )
+        );
+
+    }
+
+    /**
+     * 쿠키를 직렬화하여 객체를 저장합니다.
+     * @param obj
+     * @return 직렬화된 객체
+     */
+    public static String serialize(Object obj) {
+        return Base64.getUrlEncoder()
+                .encodeToString(SerializationUtils.serialize((Serializable) obj));
+    }
+}

--- a/src/main/java/dev/book/global/entity/BaseTimeEntity.java
+++ b/src/main/java/dev/book/global/entity/BaseTimeEntity.java
@@ -1,0 +1,36 @@
+package dev.book.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    private String createdBy;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime updatedAt;
+
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    private String updatedBy;
+
+}

--- a/src/main/java/dev/book/user/entity/UserEntity.java
+++ b/src/main/java/dev/book/user/entity/UserEntity.java
@@ -1,0 +1,57 @@
+package dev.book.user.entity;
+
+import dev.book.global.entity.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String email;
+
+    @NotNull
+    private String name;
+
+    @NotNull
+    private String nickname;
+
+    @NotNull
+    private String profileImageUrl;
+
+    private String userCategory; //추후 enum으로 변경
+
+    private long savings = 0;
+
+    private int completedChallenges = 0;
+
+    private int participatingChallenges = 0;
+
+    //todo 알림 설정 필요
+//    private NotificationPreference notificationPreference;
+
+    //todo 이후 entity과의 관계 설정 필요
+
+
+    @Builder
+    public UserEntity(String email, String name, String nickname, String profileImageUrl, String userCategory) {
+        this.email = email;
+        this.name = name;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.userCategory = userCategory;
+    }
+}

--- a/src/main/java/dev/book/user/enums/UserLoginState.java
+++ b/src/main/java/dev/book/user/enums/UserLoginState.java
@@ -1,0 +1,11 @@
+package dev.book.user.enums;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum UserLoginState {
+    LOGIN_SUCCESS("로그인 성공"),
+    PROFILE_INCOMPLETE("프로필 미설정");
+
+    private final String description;
+}

--- a/src/main/java/dev/book/user/repository/UserRepository.java
+++ b/src/main/java/dev/book/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package dev.book.user.repository;
+
+import dev.book.user.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/dev/book/user/repository/UserRepository.java
+++ b/src/main/java/dev/book/user/repository/UserRepository.java
@@ -4,7 +4,11 @@ import dev.book.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
     boolean existsByEmail(String email);
+
+    Optional<UserEntity> findByEmail(String email);
 }

--- a/src/main/java/dev/book/user/service/UserService.java
+++ b/src/main/java/dev/book/user/service/UserService.java
@@ -1,0 +1,21 @@
+package dev.book.user.service;
+
+import dev.book.user.entity.UserEntity;
+import dev.book.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public boolean isUserExist(String email){
+        return userRepository.existsByEmail(email);
+    }
+
+    public void unComplete(UserEntity newUser) {
+        userRepository.save(newUser);
+    }
+}

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -1,0 +1,24 @@
+spring:
+  security:
+    oauth2:
+      client:
+        # OAuth2 인증 제공자에 대한 설정 정보를 포함합니다.
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+        # 클라이언트 애플리케이션(Spring Boot)에 대한 설정을 포함합니다.
+        registration:
+          kakao:
+            client-id: "${oauth2_client_id}"
+            client-secret: "${oauth2_client_secret}"
+            redirect-uri: "${oauth2_redirect_uri}"
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            client-name: kakao
+            scope:
+              - profile_nickname
+              - profile_image
+              - account_email


### PR DESCRIPTION
## 설명
Spring Security 설정 및 OAuth2 로그인 구현

카카오 로그인 진행은 `/oauth2/authorization/kakao` 로 접근하시면 됩니다.

kakao에서 반환된 내역을 토대로 
처음 방문한 유저라면 우선 DB에 저장 시 `/signup` 화면으로 리다이렉트 됩니다.
유저를 조회하였을 때, 닉네임이 비어있다면 그것도 회원가입이 필요한 유저라고 파악하여 `/signup`으로 리다이렉트 돕니다.
존재하는 유저라면 `/main` 화면으로 리다이렉트 됩니다.
(리다이렉트 되는 경로는 추후 변경할 예정입니다!)

현재 UserEntity는 연관성 없이 객체만 존재합니다. 추후 개발하면서 연관성(ManyToMany, OneToMany..) 부여하시면 될 것 같습니다!

## 이슈 번호
JWT 구현에 문제가 있어.. 다음 PR 때 닫겠습니다!
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] Spring Security 설정
- [x] UserEntity 추가


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

-- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).--

우선 UserEntity에 대해 제공하는 게 먼저인 것 같아 진행한 후에 테스트는 JWT 과정까지 모두 포함하여 진행하겠습니다!
