### PR TITLE
1 feature가계부 기능 추가

### DIFF
--- a/src/main/java/dev/book/accountbook/controller/AccountBookController.java
+++ b/src/main/java/dev/book/accountbook/controller/AccountBookController.java
@@ -1,0 +1,103 @@
+package dev.book.accountbook.controller;
+
+import dev.book.accountbook.dto.request.AccountBookIncomeRequest;
+import dev.book.accountbook.dto.request.AccountBookSpendRequest;
+import dev.book.accountbook.dto.response.AccountBookIncomeResponse;
+import dev.book.accountbook.dto.response.AccountBookSpendResponse;
+import dev.book.accountbook.service.AccountBookService;
+import dev.book.global.config.security.dto.CustomUserDetails;
+import dev.book.user.entity.UserEntity;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/account-book")
+@RequiredArgsConstructor
+public class AccountBookController {
+    private final AccountBookService accountBookService;
+
+    @GetMapping("/spend")
+    public ResponseEntity<List<AccountBookSpendResponse>> spendList(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUser().getId();
+        List<AccountBookSpendResponse> responses = accountBookService.getSpendList(userId);
+
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/spend/{id}")
+    public ResponseEntity<AccountBookSpendResponse> getSpendOne(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long id) {
+        Long userId = userDetails.getUser().getId();
+        AccountBookSpendResponse response = accountBookService.getSpendOne(id,userId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/spend")
+    public ResponseEntity<AccountBookSpendResponse> createSpend(@AuthenticationPrincipal CustomUserDetails userDetails, @Valid @RequestBody AccountBookSpendRequest request) {
+        UserEntity userId = userDetails.getUser();
+        AccountBookSpendResponse response = accountBookService.createSpend(request, userId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/spend/{id}")
+    public ResponseEntity<AccountBookSpendResponse> modifySpend(@AuthenticationPrincipal CustomUserDetails userDetails, @Valid @RequestBody AccountBookSpendRequest request, @PathVariable Long id) {
+        Long userId = userDetails.getUser().getId();
+        AccountBookSpendResponse response = accountBookService.modifySpend(request, id, userId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/spend/{id}")
+    public ResponseEntity<Boolean> deleteSpend(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long id) {
+        Long userId = userDetails.getUser().getId();
+        boolean response = accountBookService.deleteSpend(id, userId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/income")
+    public ResponseEntity<List<AccountBookIncomeResponse>> incomeList(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUser().getId();
+        List<AccountBookIncomeResponse> responses = accountBookService.getIncomeList(userId);
+
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/income/{id}")
+    public ResponseEntity<AccountBookIncomeResponse> getIncomeOne(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long id) {
+        Long userId = userDetails.getUser().getId();
+        AccountBookIncomeResponse response = accountBookService.getIncomeOne(id, userId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/income")
+    public ResponseEntity<AccountBookIncomeResponse> createIncome(@AuthenticationPrincipal CustomUserDetails userDetails, @Valid @RequestBody AccountBookIncomeRequest request) {
+        UserEntity user = userDetails.getUser();
+        AccountBookIncomeResponse response = accountBookService.createIncome(request, user);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/income/{id}")
+    public ResponseEntity<AccountBookIncomeResponse> modifyIncome(@AuthenticationPrincipal CustomUserDetails userDetails, @Valid @RequestBody AccountBookIncomeRequest request, @PathVariable Long id) {
+        Long userId = userDetails.getUser().getId();
+        AccountBookIncomeResponse response = accountBookService.modifyIncome(id, request, userId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/income/{id}")
+    public ResponseEntity<Boolean> deleteIncome(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long id) {
+        Long userId = userDetails.getUser().getId();
+        boolean response = accountBookService.deleteIncome(id, userId);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/dev/book/accountbook/dto/request/AccountBookIncomeRequest.java
+++ b/src/main/java/dev/book/accountbook/dto/request/AccountBookIncomeRequest.java
@@ -1,0 +1,16 @@
+package dev.book.accountbook.dto.request;
+
+import dev.book.accountbook.type.Category;
+import dev.book.accountbook.type.CategoryType;
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDateTime;
+
+public record AccountBookIncomeRequest(@NotNull @Size(max = 50) String title, Category category, @NotNull @Min(10) @Max(100000000) int amount, @Size(max = 1000) String memo, LocalDateTime endDate, Repeat repeat
+) implements AccountBookRequest {
+
+    @Override
+    public CategoryType categoryType() {
+        return CategoryType.INCOME;
+    }
+}

--- a/src/main/java/dev/book/accountbook/dto/request/AccountBookRequest.java
+++ b/src/main/java/dev/book/accountbook/dto/request/AccountBookRequest.java
@@ -1,0 +1,47 @@
+package dev.book.accountbook.dto.request;
+
+import dev.book.accountbook.entity.AccountBook;
+import dev.book.accountbook.type.Category;
+import dev.book.accountbook.type.CategoryType;
+import dev.book.accountbook.type.Frequency;
+import dev.book.user.entity.UserEntity;
+
+import java.time.LocalDateTime;
+
+public interface AccountBookRequest {
+    String title();
+    Category category();
+    int amount();
+    String memo();
+    LocalDateTime endDate();
+    Repeat repeat();
+    CategoryType categoryType();
+
+    default AccountBook toEntity(UserEntity user) {
+        Frequency frequency = null;
+        Integer month = null;
+        Integer day = null;
+
+        if (repeat() != null) {
+            frequency = repeat().frequency();
+            month = repeat().month();
+            day = repeat().day();
+        }
+
+        return new AccountBook(
+                null,
+                title(),
+                category(),
+                categoryType(),
+                amount(),
+                null,
+                null,
+                endDate(),
+                memo(),
+                user,
+                frequency,
+                month,
+                day
+        );
+    }
+}

--- a/src/main/java/dev/book/accountbook/dto/request/AccountBookSpendRequest.java
+++ b/src/main/java/dev/book/accountbook/dto/request/AccountBookSpendRequest.java
@@ -1,0 +1,14 @@
+package dev.book.accountbook.dto.request;
+
+import dev.book.accountbook.type.Category;
+import dev.book.accountbook.type.CategoryType;
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDateTime;
+
+public record AccountBookSpendRequest(@NotBlank @Size(max = 50) String title, Category category, @NotNull @Min(10) @Max(100000000) int amount, @Size(max = 1000) String memo, LocalDateTime endDate, Repeat repeat) implements AccountBookRequest {
+    @Override
+    public CategoryType categoryType() {
+        return CategoryType.SPEND;
+    }
+}

--- a/src/main/java/dev/book/accountbook/dto/request/Repeat.java
+++ b/src/main/java/dev/book/accountbook/dto/request/Repeat.java
@@ -1,0 +1,6 @@
+package dev.book.accountbook.dto.request;
+
+import dev.book.accountbook.type.Frequency;
+
+public record Repeat(Frequency frequency, Integer month, Integer day) {
+}

--- a/src/main/java/dev/book/accountbook/dto/response/AccountBookIncomeResponse.java
+++ b/src/main/java/dev/book/accountbook/dto/response/AccountBookIncomeResponse.java
@@ -1,0 +1,23 @@
+package dev.book.accountbook.dto.response;
+
+import dev.book.accountbook.dto.request.Repeat;
+import dev.book.accountbook.entity.AccountBook;
+import dev.book.accountbook.type.Category;
+
+import java.time.LocalDateTime;
+
+public record AccountBookIncomeResponse(Long id, String title, Category category, int amount, LocalDateTime modifyDate,
+                                        String memo, LocalDateTime endDate, Repeat repeat) {
+    public static AccountBookIncomeResponse from(AccountBook entity) {
+        return new AccountBookIncomeResponse(
+                entity.getId(),
+                entity.getTitle(),
+                entity.getCategory(),
+                entity.getAmount(),
+                entity.getCreateDate(),
+                entity.getMemo(),
+                entity.getEndDate(),
+                new Repeat(entity.getFrequency(), entity.getMonth(), entity.getDay())
+        );
+    }
+}

--- a/src/main/java/dev/book/accountbook/dto/response/AccountBookSpendResponse.java
+++ b/src/main/java/dev/book/accountbook/dto/response/AccountBookSpendResponse.java
@@ -1,0 +1,22 @@
+package dev.book.accountbook.dto.response;
+
+import dev.book.accountbook.dto.request.Repeat;
+import dev.book.accountbook.entity.AccountBook;
+import dev.book.accountbook.type.Category;
+
+import java.time.LocalDateTime;
+
+public record AccountBookSpendResponse(Long id, String title, Category category, int amount, LocalDateTime modifyDate, String memo, LocalDateTime endDate, Repeat repeat) {
+    public static AccountBookSpendResponse from(AccountBook entity) {
+        return new AccountBookSpendResponse(
+                entity.getId(),
+                entity.getTitle(),
+                entity.getCategory(),
+                entity.getAmount(),
+                entity.getModifyDate(),
+                entity.getMemo(),
+                entity.getEndDate(),
+                new Repeat(entity.getFrequency(), entity.getMonth(), entity.getDay())
+        );
+    }
+}

--- a/src/main/java/dev/book/accountbook/entity/AccountBook.java
+++ b/src/main/java/dev/book/accountbook/entity/AccountBook.java
@@ -1,0 +1,83 @@
+package dev.book.accountbook.entity;
+
+import dev.book.accountbook.type.Category;
+import dev.book.accountbook.type.CategoryType;
+import dev.book.accountbook.type.Frequency;
+import dev.book.user.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class AccountBook {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String title;
+    @Enumerated(value = EnumType.STRING)
+    private Category category;
+    @Enumerated(value = EnumType.STRING)
+    private CategoryType type;
+    private int amount;
+    @CreatedDate
+    private LocalDateTime createDate;
+    @LastModifiedDate
+    private LocalDateTime modifyDate;
+    private LocalDateTime endDate;
+    private String memo;
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+    @Enumerated(EnumType.STRING)
+    private Frequency frequency;
+    private Integer month;
+    private Integer day;
+
+    public void modifyTitle(String title) {
+        this.title = title;
+    }
+
+    public void modifyCategory(Category category) {
+        this.category = category;
+    }
+
+    public void modifyAmount(int amount) {
+        this.amount = amount;
+    }
+
+    public void modifyDate() {
+        this.modifyDate = LocalDateTime.now();
+    }
+
+    public void modifyMemo(String memo) {
+        this.memo = memo;
+    }
+
+    public void modifyFrequency(Frequency frequency) {
+        this.frequency = frequency;
+    }
+
+    public void modifyMonth(Integer month) {
+        this.month = month;
+    }
+
+    public void modifyDay(Integer day) {
+        this.day = day;
+    }
+
+    public void modifyEndDate(LocalDateTime endDate) {
+        this.endDate = endDate;
+    }
+}

--- a/src/main/java/dev/book/accountbook/exception/AccountBookErrorCode.java
+++ b/src/main/java/dev/book/accountbook/exception/AccountBookErrorCode.java
@@ -1,0 +1,15 @@
+package dev.book.accountbook.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AccountBookErrorCode implements ErrorCode {
+    NOT_FOUND_SPEND(HttpStatus.BAD_REQUEST, "존재하지 않는 소비내역입니다."),
+    NOT_FOUND_INCOME(HttpStatus.BAD_REQUEST, "존재하지 않는 수입내역입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/dev/book/accountbook/exception/AccountBookErrorException.java
+++ b/src/main/java/dev/book/accountbook/exception/AccountBookErrorException.java
@@ -1,0 +1,21 @@
+package dev.book.accountbook.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AccountBookErrorException extends CustomErrorException {
+    private final AccountBookErrorCode errorCode;
+    private final Object additionalDate;
+
+    public AccountBookErrorException(AccountBookErrorCode errorCode) {
+        super(errorCode.getMessage(), errorCode);
+        this.errorCode = errorCode;
+        this.additionalDate = null;
+    }
+
+    public AccountBookErrorException(AccountBookErrorCode errorCode, Object additionalDate) {
+        super(errorCode.getMessage() + " " + additionalDate, errorCode);
+        this.errorCode = errorCode;
+        this.additionalDate = additionalDate;
+    }
+}

--- a/src/main/java/dev/book/accountbook/exception/AccountBookErrorHandler.java
+++ b/src/main/java/dev/book/accountbook/exception/AccountBookErrorHandler.java
@@ -1,0 +1,49 @@
+package dev.book.accountbook.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestControllerAdvice
+public class AccountBookErrorHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidationErrorException(MethodArgumentNotValidException ex) {
+        List<Map<String, String>> errorDetails = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> {
+                    Map<String, String> fieldError = new HashMap<>();
+                    fieldError.put("field", error.getField());
+                    fieldError.put("message", error.getDefaultMessage());
+                    fieldError.put("code", error.getCode());
+
+                    return fieldError;
+                }).toList();
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("timestamp", LocalDateTime.now());
+        response.put("status", HttpStatus.BAD_REQUEST.value());
+        response.put("message", "Validation failed");
+        response.put("errors", errorDetails);
+
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    @ExceptionHandler(AccountBookErrorException.class)
+    public ResponseEntity<Map<String, Object>> handleAccountBookErrorException(AccountBookErrorException ex) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", ex.getErrorCode().getStatus().value());
+        response.put("message", ex.getErrorCode().getMessage());
+
+        return new ResponseEntity<>(response, ex.getErrorCode().getStatus());
+    }
+}

--- a/src/main/java/dev/book/accountbook/exception/CustomErrorException.java
+++ b/src/main/java/dev/book/accountbook/exception/CustomErrorException.java
@@ -1,0 +1,13 @@
+package dev.book.accountbook.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomErrorException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomErrorException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/dev/book/accountbook/exception/ErrorCode.java
+++ b/src/main/java/dev/book/accountbook/exception/ErrorCode.java
@@ -1,0 +1,8 @@
+package dev.book.accountbook.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getStatus();
+    String getMessage();
+}

--- a/src/main/java/dev/book/accountbook/repository/AccountBookRepository.java
+++ b/src/main/java/dev/book/accountbook/repository/AccountBookRepository.java
@@ -1,0 +1,58 @@
+package dev.book.accountbook.repository;
+
+import dev.book.accountbook.dto.response.AccountBookStatResponse;
+import dev.book.accountbook.entity.AccountBook;
+import dev.book.accountbook.type.Category;
+import dev.book.accountbook.type.CategoryType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface AccountBookRepository extends JpaRepository<AccountBook, Long> {
+    Optional<AccountBook> findByIdAndUserId(Long id, Long userId);
+
+    List<AccountBook> findAllByUserIdAndType(Long userId, CategoryType type);
+
+    @Query("""
+            SELECT new dev.book.accountbook.dto.response.AccountBookStatResponse(a.category, SUM(a.amount))
+                        FROM AccountBook a
+                        WHERE a.user.id = :userId
+                        AND a.modifyDate BETWEEN :startDate AND :endDate
+                        GROUP BY a.category
+                        ORDER BY SUM(a.amount) DESC
+            """)
+    List<AccountBookStatResponse> findTop3Categories(@Param("userId") Long userId, @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, Pageable pageable);
+
+    @Query("""
+              SELECT a
+                  FROM AccountBook a
+                  WHERE a.user.id = :userId
+                  AND a.type = :categoryType
+                  AND a.category = :category
+            AND a.modifyDate BETWEEN :startDate AND :endDate
+            """)
+    List<AccountBook> findByCategory(Long userId, CategoryType categoryType, Category category, LocalDateTime startDate, LocalDateTime endDate);
+
+    @Query("""
+                SELECT COALESCE(SUM(a.amount), 0)
+                    FROM AccountBook a
+                    WHERE a.user.id = :userId
+                    AND a.type = :categoryType
+                    AND a.category = :category
+                    AND a.modifyDate BETWEEN :startDate AND :endDate
+            """)
+    Integer sumSpending(
+            @Param("userId") Long userId,
+            @Param("categoryType") CategoryType categoryType,
+            @Param("category") Category category,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
+}

--- a/src/main/java/dev/book/accountbook/service/AccountBookService.java
+++ b/src/main/java/dev/book/accountbook/service/AccountBookService.java
@@ -1,0 +1,111 @@
+package dev.book.accountbook.service;
+
+import dev.book.accountbook.dto.request.AccountBookIncomeRequest;
+import dev.book.accountbook.dto.request.AccountBookRequest;
+import dev.book.accountbook.dto.request.AccountBookSpendRequest;
+import dev.book.accountbook.dto.response.AccountBookIncomeResponse;
+import dev.book.accountbook.dto.response.AccountBookSpendResponse;
+import dev.book.accountbook.entity.AccountBook;
+import dev.book.accountbook.exception.AccountBookErrorCode;
+import dev.book.accountbook.exception.AccountBookErrorException;
+import dev.book.accountbook.repository.AccountBookRepository;
+import dev.book.accountbook.type.CategoryType;
+import dev.book.user.entity.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AccountBookService {
+    private final AccountBookRepository accountBookRepository;
+
+    public AccountBookSpendResponse getSpendOne(Long id, Long userId) {
+        AccountBook accountBook = findAccountBookOrThrow(id, userId, AccountBookErrorCode.NOT_FOUND_SPEND);
+
+        return AccountBookSpendResponse.from(accountBook);
+    }
+
+    public List<AccountBookSpendResponse> getSpendList(Long userId) {
+        List<AccountBook> accountBooks = accountBookRepository.findAllByUserIdAndType(userId, CategoryType.SPEND);
+
+        return accountBooks.stream()
+                .map(AccountBookSpendResponse::from)
+                .toList();
+    }
+
+    public AccountBookSpendResponse createSpend(AccountBookSpendRequest spendRequest, UserEntity user) {
+        AccountBook accountBook = accountBookRepository.save(spendRequest.toEntity(user));
+
+        return AccountBookSpendResponse.from(accountBook);
+    }
+
+    @Transactional
+    public AccountBookSpendResponse modifySpend(AccountBookSpendRequest request, Long id, Long userId) {
+        AccountBook accountBook = findAccountBookOrThrow(id, userId, AccountBookErrorCode.NOT_FOUND_SPEND);
+        updateAccountBook(accountBook, request);
+
+        return AccountBookSpendResponse.from(accountBook);
+    }
+
+    public boolean deleteSpend(Long id, Long userId) {
+        AccountBook accountBook = findAccountBookOrThrow(id, userId, AccountBookErrorCode.NOT_FOUND_SPEND);
+        accountBookRepository.deleteById(accountBook.getId());
+
+        return true;
+    }
+
+    public AccountBookIncomeResponse getIncomeOne(Long id, Long userId) {
+        AccountBook accountBook = findAccountBookOrThrow(id, userId, AccountBookErrorCode.NOT_FOUND_INCOME);
+
+        return AccountBookIncomeResponse.from(accountBook);
+    }
+
+    public List<AccountBookIncomeResponse> getIncomeList(Long userId) {
+        List<AccountBook> accountBooks = accountBookRepository.findAllByUserIdAndType(userId, CategoryType.INCOME);
+
+        return accountBooks.stream()
+                .map(AccountBookIncomeResponse::from)
+                .toList();
+    }
+
+    public AccountBookIncomeResponse createIncome(AccountBookIncomeRequest request, UserEntity user) {
+        AccountBook accountBook = accountBookRepository.save(request.toEntity(user));
+
+        return AccountBookIncomeResponse.from(accountBook);
+    }
+
+    @Transactional
+    public AccountBookIncomeResponse modifyIncome(Long id, AccountBookIncomeRequest request, Long userId) {
+        AccountBook accountBook = findAccountBookOrThrow(id, userId, AccountBookErrorCode.NOT_FOUND_INCOME);
+        updateAccountBook(accountBook, request);
+
+        return AccountBookIncomeResponse.from(accountBook);
+    }
+
+    public boolean deleteIncome(Long id, Long userId) {
+        AccountBook accountBook = findAccountBookOrThrow(id, userId, AccountBookErrorCode.NOT_FOUND_INCOME);
+        accountBookRepository.deleteById(accountBook.getId());
+
+        return true;
+    }
+
+    private AccountBook findAccountBookOrThrow(Long id, Long userId, AccountBookErrorCode errorCode) {
+        return accountBookRepository.findByIdAndUserId(id, userId)
+                .orElseThrow(() -> new AccountBookErrorException(errorCode));
+    }
+
+    private void updateAccountBook(AccountBook accountBook, AccountBookRequest request) {
+        accountBook.modifyTitle(request.title());
+        accountBook.modifyCategory(request.category());
+        accountBook.modifyAmount(request.amount());
+        accountBook.modifyDate();
+        accountBook.modifyMemo(request.memo());
+        accountBook.modifyFrequency(request.repeat().frequency());
+        accountBook.modifyMonth(request.repeat().month());
+        accountBook.modifyDay(request.repeat().day());
+        accountBook.modifyEndDate(request.endDate());
+    }
+}

--- a/src/main/java/dev/book/accountbook/type/Category.java
+++ b/src/main/java/dev/book/accountbook/type/Category.java
@@ -1,0 +1,59 @@
+package dev.book.accountbook.type;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+public enum Category {
+    TRANSFER("이체", CategoryType.INCOME),
+    SALARY("급여", CategoryType.INCOME),
+    SAVING_INVESTMENT("저축 / 투자", CategoryType.INCOME),
+
+    FOOD("식비", CategoryType.SPEND),
+    CAFE_SNACK("카페 / 간식", CategoryType.SPEND),
+    CONVENIENCE_STORE("편의점 / 마트 / 잡화", CategoryType.SPEND),
+    ALCOHOL_ENTERTAINMENT("술 / 유흥", CategoryType.SPEND),
+    SHOPPING("쇼핑", CategoryType.SPEND),
+    HOBBY("취미 / 여가", CategoryType.SPEND),
+    HEALTH("의료 / 건강 / 피트니스", CategoryType.SPEND),
+    HOUSING_COMMUNICATION("주거 / 통신", CategoryType.SPEND),
+    FINANCE("보험 / 세금 / 기타금융", CategoryType.SPEND),
+    BEAUTY("미용", CategoryType.SPEND),
+    TRANSPORTATION("교통 / 자동차", CategoryType.SPEND),
+    TRAVEL("여행 / 숙박", CategoryType.SPEND),
+    EDUCATION("교육", CategoryType.SPEND),
+    LIVING("생활", CategoryType.SPEND),
+    DONATION("기부 / 후원", CategoryType.SPEND),
+    CARD_PAYMENT("카드대금", CategoryType.SPEND),
+    DEFERRED_PAYMENT("후불결제대금", CategoryType.SPEND),
+
+    NONE("카테고리 미설정", CategoryType.SPEND);
+
+    private final String koreanName;
+    private final CategoryType type;
+
+    private static final Map<String, Category> KOREAN_NAME_MAP =
+            Arrays.stream(values())
+                    .collect(Collectors.toMap(Category::getKoreanName, c -> c));
+
+    @JsonCreator
+    public static Category from(String input) {
+        if (input == null || input.trim().isEmpty()) {
+            return Category.NONE;
+        }
+
+        Category category = KOREAN_NAME_MAP.get(input);
+
+        if (category == null) {
+            throw new IllegalArgumentException("유효하지 않은 소비 카테고리입니다: " + input);
+        }
+
+        return category;
+    }
+}

--- a/src/main/java/dev/book/accountbook/type/CategoryType.java
+++ b/src/main/java/dev/book/accountbook/type/CategoryType.java
@@ -1,0 +1,5 @@
+package dev.book.accountbook.type;
+
+public enum CategoryType {
+    INCOME, SPEND
+}

--- a/src/main/java/dev/book/accountbook/type/Frequency.java
+++ b/src/main/java/dev/book/accountbook/type/Frequency.java
@@ -1,0 +1,18 @@
+package dev.book.accountbook.type;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum Frequency {
+    WEEKLY, MONTHLY, YEARLY;
+
+    @JsonCreator
+    public static Frequency from(String value) {
+        return Frequency.valueOf(value.toUpperCase());
+    }
+
+    @JsonValue
+    public String toJson() {
+        return this.name().toLowerCase();
+    }
+}


### PR DESCRIPTION
## 설명
가계부에 사용자의 지출 / 수입을 등록할 수 있는 기능을 추가했습니다. 단순, 고정 지출 / 수입을 등록할 수 있습니다.
고정 지출 / 수입의 경우 종료일자는 선택사항으로 하였고 매주 고정의 경우 요일, 매월은 날짜, 매년은 월과 날짜를 받습니다.
    
## 이슈 번호
Resolves: #1 

## PR 유형
어떤 변경 사항이 있나요?

- 지출
    - 지출 등록
    - 지출 목록 반환
    - 지출 정보 자세히 보기
    - 지출 수정
    - 지출 삭제
- 수입
    - 수입 등록
    - 수입 목록 반환
    - 수입 정보 자세히 보기
    - 수입 수정
    - 수입 삭제


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [유저를 포함한 테스트 코드 작성해서 다음 pr에 올리겠습니다.
