### PR TITLE
24, 40, 58 feature 유저 기능 중 프론트 측 요구 api 추가 및 유저 기능 추가

### DIFF
--- a/src/main/java/dev/book/accountbook/repository/AccountBookRepository.java
+++ b/src/main/java/dev/book/accountbook/repository/AccountBookRepository.java
@@ -181,7 +181,7 @@ public interface AccountBookRepository extends JpaRepository<AccountBook, Long> 
     Integer sumSpendingInCategories(@Param("userId") Long userId,
                                     @Param("categoryType") CategoryType categoryType,
                                     @Param("categories") List<Category> category,
-                                    @Param("startDate") LocalDateTime startDate,
-                                    @Param("endDate") LocalDateTime endDate
+                                    @Param("startDate") LocalDate startDate,
+                                    @Param("endDate") LocalDate endDate
     );
 }

--- a/src/main/java/dev/book/achievement/achievement_user/entity/AchievementUser.java
+++ b/src/main/java/dev/book/achievement/achievement_user/entity/AchievementUser.java
@@ -7,12 +7,14 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class AchievementUser {
 
     @Id

--- a/src/main/java/dev/book/achievement/achievement_user/repository/AchievementUserRepository.java
+++ b/src/main/java/dev/book/achievement/achievement_user/repository/AchievementUserRepository.java
@@ -3,10 +3,16 @@ package dev.book.achievement.achievement_user.repository;
 import dev.book.achievement.achievement_user.entity.AchievementUser;
 import dev.book.achievement.entity.Achievement;
 import dev.book.user.entity.UserEntity;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface AchievementUserRepository extends JpaRepository<AchievementUser, Long> {
     boolean existsByAchievementAndUser(Achievement achievement, UserEntity user);
+
+    @EntityGraph(attributePaths = "achievement")
+    List<AchievementUser> findAllByUser(UserEntity user);
 }

--- a/src/main/java/dev/book/achievement/entity/Achievement.java
+++ b/src/main/java/dev/book/achievement/entity/Achievement.java
@@ -19,4 +19,9 @@ public class Achievement {
     private String title;
 
     private String content;
+
+    public Achievement(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/src/main/java/dev/book/challenge/challenge_invite/entity/ChallengeInvite.java
+++ b/src/main/java/dev/book/challenge/challenge_invite/entity/ChallengeInvite.java
@@ -48,7 +48,7 @@ public class ChallengeInvite extends BaseTimeEntity {
 
     public void accept() {
         this.isAccept = true;
-        this.inviteUser.plusChallengeCount();
+        this.inviteUser.plusParticipatingChallenge();
         this.challenge.plusCurrentCapacity();
     }
 

--- a/src/main/java/dev/book/challenge/scheduler/ChallengeScheduler.java
+++ b/src/main/java/dev/book/challenge/scheduler/ChallengeScheduler.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
 
 @Component
@@ -40,11 +39,15 @@ public class ChallengeScheduler {
             List<Category> categoryList = ChallengeCategory.getCategoryList(challenge.getChallengeCategories());
             users.forEach( user-> {
                 Integer sumOfCategories = accountBookRepository.sumSpendingInCategories(
-                        user.getId(), CategoryType.SPEND, categoryList, challenge.getStartDate().atStartOfDay(), challenge.getEndDate().atTime(LocalTime.MAX));
-                if (sumOfCategories <= challenge.getAmount())
+                        user.getId(), CategoryType.SPEND, categoryList, challenge.getStartDate(), challenge.getEndDate());
+                if (sumOfCategories <= challenge.getAmount()){
+                    user.plusCompleteChallenge();
+                    user.plusSavings(challenge.getAmount() - sumOfCategories);
                     eventPublisher.publishEvent(new CompleteChallengeEvent(user));
-                else
+                } else{
                     eventPublisher.publishEvent(new FailChallengeEvent(user));
+                }
+                user.plusFinishedChallenge();
             });
         }
     }

--- a/src/main/java/dev/book/challenge/service/ChallengeInviteService.java
+++ b/src/main/java/dev/book/challenge/service/ChallengeInviteService.java
@@ -74,7 +74,7 @@ public class ChallengeInviteService {
 
         ChallengeInvite challengeInvite = challengeInviteRepository.findByIdAndInviteUserId(inviteId, user.getId()).orElseThrow(() -> new ChallengeException(CHALLENGE_NOT_FOUND_INVITED));
         challengeInvite.accept();
-        user.plusChallengeCount();
+        user.plusParticipatingChallenge();
         challengeInviteRepository.delete(challengeInvite);
 
         UserChallenge userChallenge = UserChallenge.of(user, challengeInvite.getChallenge());

--- a/src/main/java/dev/book/challenge/service/ChallengeService.java
+++ b/src/main/java/dev/book/challenge/service/ChallengeService.java
@@ -53,7 +53,7 @@ public class ChallengeService {
         userChallengeRepository.save(userChallenge);
 
         eventPublisher.publishEvent(new CreateChallengeEvent(user));
-        creator.plusChallengeCount();
+        creator.plusParticipatingChallenge();
         return ChallengeCreateResponse.fromEntity(challenge);
 
     }
@@ -89,7 +89,7 @@ public class ChallengeService {
         List<UserEntity> users = userRepository.findAllById(userIds);
 
         for (UserEntity participant : users) {
-            participant.minusChallengeCount();
+            participant.minusParticipatingChallenge();
         } // 만약에 챌린지가 완료후 챌린지가 삭제 되면 이것도 삭제되는데
 
         challengeRepository.delete(challenge);
@@ -106,7 +106,7 @@ public class ChallengeService {
         challenge.isParticipantsMoreThanCapacity();
         challenge.plusCurrentCapacity();
 
-        userEntity.plusChallengeCount();
+        userEntity.plusParticipatingChallenge();
         UserChallenge userChallenge = UserChallenge.of(userEntity, challenge);
         userChallengeRepository.save(userChallenge);
     }
@@ -118,7 +118,7 @@ public class ChallengeService {
         UserEntity userEntity = userRepository.findByEmail(user.getEmail()).orElseThrow(() -> new UserErrorException(USER_NOT_FOUND));
         checkNotExist(user, challenge.getId());
 
-        userEntity.minusChallengeCount();
+        userEntity.minusParticipatingChallenge();
         challenge.minusCurrentCapacity();
         userChallengeRepository.deleteByUserIdAndChallengeId(userEntity.getId(), challenge.getId());
 

--- a/src/main/java/dev/book/global/config/jpa/JpaConfig.java
+++ b/src/main/java/dev/book/global/config/jpa/JpaConfig.java
@@ -4,6 +4,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Optional;
@@ -14,6 +16,15 @@ public class JpaConfig {
 
     @Bean
     public AuditorAware<String> auditorProvider() {
-        return () -> Optional.of(SecurityContextHolder.getContext().getAuthentication().getName());
+        return () -> {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+            if (authentication == null || !authentication.isAuthenticated() ||
+                    authentication instanceof AnonymousAuthenticationToken) {
+                return Optional.of("SYSTEM");
+            }
+
+            return Optional.ofNullable(authentication.getName());
+        };
     }
 }

--- a/src/main/java/dev/book/global/config/security/SecurityConfig.java
+++ b/src/main/java/dev/book/global/config/security/SecurityConfig.java
@@ -10,6 +10,7 @@ import dev.book.global.config.security.handler.OAuth2SuccessHandler;
 import dev.book.global.config.security.jwt.JwtUtil;
 import dev.book.global.config.security.service.oauth2.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -32,6 +33,9 @@ import java.util.List;
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    @Value("${springdoc.servers.production.url}")
+    private String DOMAIN;
 
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final OAuth2FailureHandler oAuth2FailureHandler;
@@ -85,7 +89,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource(){
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:8080","http://localhost:63342"));
+        config.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:8080","http://localhost:63342", DOMAIN));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH"));
         config.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With", "Accept", "Cache-Control"));
         config.setMaxAge(3600L);

--- a/src/main/java/dev/book/global/config/security/util/CookieUtil.java
+++ b/src/main/java/dev/book/global/config/security/util/CookieUtil.java
@@ -23,6 +23,7 @@ public class CookieUtil {
         cookie.setHttpOnly(true);
 //        cookie.setSecure(true);
         cookie.setMaxAge(maxAge);
+        cookie.setAttribute("SameSite", "None");
         response.addCookie(cookie);
     }
 
@@ -43,6 +44,7 @@ public class CookieUtil {
                 cookie.setMaxAge(0);
 //                cookie.setSecure(true);
                 cookie.setPath("/");
+                cookie.setAttribute("SameSite", "None");
                 response.addCookie(cookie);
             }
         }

--- a/src/main/java/dev/book/global/config/security/util/CookieUtil.java
+++ b/src/main/java/dev/book/global/config/security/util/CookieUtil.java
@@ -23,7 +23,7 @@ public class CookieUtil {
         cookie.setHttpOnly(true);
 //        cookie.setSecure(true);
         cookie.setMaxAge(maxAge);
-        cookie.setAttribute("SameSite", "None");
+//        cookie.setAttribute("SameSite", "None");
         response.addCookie(cookie);
     }
 
@@ -44,7 +44,7 @@ public class CookieUtil {
                 cookie.setMaxAge(0);
 //                cookie.setSecure(true);
                 cookie.setPath("/");
-                cookie.setAttribute("SameSite", "None");
+//                cookie.setAttribute("SameSite", "None");
                 response.addCookie(cookie);
             }
         }

--- a/src/main/java/dev/book/global/config/security/util/CookieUtil.java
+++ b/src/main/java/dev/book/global/config/security/util/CookieUtil.java
@@ -21,9 +21,9 @@ public class CookieUtil {
         Cookie cookie = new Cookie(name, value);
         cookie.setPath("/");
         cookie.setHttpOnly(true);
-//        cookie.setSecure(true);
+        cookie.setSecure(true);
         cookie.setMaxAge(maxAge);
-//        cookie.setAttribute("SameSite", "None");
+        cookie.setAttribute("SameSite", "None");
         response.addCookie(cookie);
     }
 
@@ -42,9 +42,9 @@ public class CookieUtil {
             if (cookie.getName().equals(name)) {
                 cookie.setValue("");
                 cookie.setMaxAge(0);
-//                cookie.setSecure(true);
+                cookie.setSecure(true);
                 cookie.setPath("/");
-//                cookie.setAttribute("SameSite", "None");
+                cookie.setAttribute("SameSite", "None");
                 response.addCookie(cookie);
             }
         }

--- a/src/main/java/dev/book/user/controller/UserController.java
+++ b/src/main/java/dev/book/user/controller/UserController.java
@@ -5,6 +5,7 @@ import dev.book.user.dto.request.UserCategoriesRequest;
 import dev.book.user.dto.request.UserProfileUpdateRequest;
 import dev.book.user.dto.response.UserAchievementResponse;
 import dev.book.user.dto.response.UserCategoryResponse;
+import dev.book.user.dto.response.UserChallengeInfoResponse;
 import dev.book.user.dto.response.UserProfileResponse;
 import dev.book.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -74,11 +75,16 @@ public class UserController implements UserSwaggerController{
         return ResponseEntity.ok().build();
     }
 
-    //todo 업적, 통계, 경고 반환
     @GetMapping("/achievement")
     public ResponseEntity<List<UserAchievementResponse>> getUserAchievement(@AuthenticationPrincipal CustomUserDetails userDetails){
         return ResponseEntity.ok()
                 .body(userService.getUserAchievement(userDetails));
+    }
+
+    @GetMapping("/challenge")
+    public ResponseEntity<UserChallengeInfoResponse> getUserChallengeInfo(@AuthenticationPrincipal CustomUserDetails userDetails){
+        return ResponseEntity.ok()
+                .body(userService.getUserChallengeInfo(userDetails));
     }
 
 }

--- a/src/main/java/dev/book/user/controller/UserController.java
+++ b/src/main/java/dev/book/user/controller/UserController.java
@@ -53,4 +53,18 @@ public class UserController implements UserSwaggerController{
         userService.checkIsUserLogin(userDetails);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/validate/nickname")
+    public ResponseEntity<Boolean> checkIsValidateNickname(@RequestParam(name = "nickname", required = true) String nickname){
+        userService.checkIsValidateNickname(nickname);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/delete/nickname")
+    public ResponseEntity<?> deleteUserNickname(@AuthenticationPrincipal CustomUserDetails userDetails){
+        userService.deleteUserNickname(userDetails);
+        return ResponseEntity.ok().build();
+    }
+
+
 }

--- a/src/main/java/dev/book/user/controller/UserController.java
+++ b/src/main/java/dev/book/user/controller/UserController.java
@@ -3,6 +3,7 @@ package dev.book.user.controller;
 import dev.book.global.config.security.dto.CustomUserDetails;
 import dev.book.user.dto.request.UserCategoriesRequest;
 import dev.book.user.dto.request.UserProfileUpdateRequest;
+import dev.book.user.dto.response.UserAchievementResponse;
 import dev.book.user.dto.response.UserCategoryResponse;
 import dev.book.user.dto.response.UserProfileResponse;
 import dev.book.user.service.UserService;
@@ -12,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -72,5 +75,10 @@ public class UserController implements UserSwaggerController{
     }
 
     //todo 업적, 통계, 경고 반환
+    @GetMapping("/achievement")
+    public ResponseEntity<List<UserAchievementResponse>> getUserAchievement(@AuthenticationPrincipal CustomUserDetails userDetails){
+        return ResponseEntity.ok()
+                .body(userService.getUserAchievement(userDetails));
+    }
 
 }

--- a/src/main/java/dev/book/user/controller/UserController.java
+++ b/src/main/java/dev/book/user/controller/UserController.java
@@ -3,6 +3,7 @@ package dev.book.user.controller;
 import dev.book.global.config.security.dto.CustomUserDetails;
 import dev.book.user.dto.request.UserCategoriesRequest;
 import dev.book.user.dto.request.UserProfileUpdateRequest;
+import dev.book.user.dto.response.UserCategoryResponse;
 import dev.book.user.dto.response.UserProfileResponse;
 import dev.book.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,10 +33,8 @@ public class UserController implements UserSwaggerController{
                 .body(userService.updateUserProfile(profileUpdateRequest, userDetails));
     }
 
-    //todo 업적, 통계, 경고 반환
-
     @GetMapping("/categories")
-    public ResponseEntity<?> getUserCategories(@AuthenticationPrincipal CustomUserDetails userDetails){
+    public ResponseEntity<UserCategoryResponse> getUserCategories(@AuthenticationPrincipal CustomUserDetails userDetails){
         return ResponseEntity.ok()
                 .body(userService.getUserCategories(userDetails));
     }
@@ -71,4 +70,7 @@ public class UserController implements UserSwaggerController{
         userService.deleteUserNickname(userDetails);
         return ResponseEntity.ok().build();
     }
+
+    //todo 업적, 통계, 경고 반환
+
 }

--- a/src/main/java/dev/book/user/controller/UserController.java
+++ b/src/main/java/dev/book/user/controller/UserController.java
@@ -25,13 +25,19 @@ public class UserController implements UserSwaggerController{
                 .body(userService.getUserProfile(userDetails));
     }
 
-    //todo 업적, 통계, 경고 반환
-
     @PutMapping("/profile")
     public ResponseEntity<UserProfileResponse> updateUserProfile(@RequestBody UserProfileUpdateRequest profileUpdateRequest,
                                                                  @AuthenticationPrincipal CustomUserDetails userDetails){
         return ResponseEntity.ok()
                 .body(userService.updateUserProfile(profileUpdateRequest, userDetails));
+    }
+
+    //todo 업적, 통계, 경고 반환
+
+    @GetMapping("/categories")
+    public ResponseEntity<?> getUserCategories(@AuthenticationPrincipal CustomUserDetails userDetails){
+        return ResponseEntity.ok()
+                .body(userService.getUserCategories(userDetails));
     }
 
     @PutMapping("/categories")
@@ -65,6 +71,4 @@ public class UserController implements UserSwaggerController{
         userService.deleteUserNickname(userDetails);
         return ResponseEntity.ok().build();
     }
-
-
 }

--- a/src/main/java/dev/book/user/controller/UserSwaggerController.java
+++ b/src/main/java/dev/book/user/controller/UserSwaggerController.java
@@ -1,11 +1,15 @@
 package dev.book.user.controller;
 
+import dev.book.accountbook.dto.response.AccountBookSpendResponse;
 import dev.book.global.config.security.dto.CustomUserDetails;
 import dev.book.user.dto.request.UserCategoriesRequest;
 import dev.book.user.dto.request.UserProfileUpdateRequest;
+import dev.book.user.dto.response.UserAchievementResponse;
 import dev.book.user.dto.response.UserCategoryResponse;
+import dev.book.user.dto.response.UserChallengeInfoResponse;
 import dev.book.user.dto.response.UserProfileResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -17,7 +21,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "User API", description = "유저 프로필 조회, 수정, 유저 삭제 api")
+import java.util.List;
+
+@Tag(name = "유저 API", description = "유저 프로필 조회, 수정, 삭제, 카테고리 관리, 마이페이지의 업적, 통계 반환 api")
 public interface UserSwaggerController {
 
     @Operation(summary = "유저 삭제(회원 탈퇴)", description = "현재 로그인된 유저를 탈퇴시킵니다.")
@@ -81,5 +87,22 @@ public interface UserSwaggerController {
             @ApiResponse(responseCode = "200", description = "닉네임 삭제 완료"),
     })
     ResponseEntity<?> deleteUserNickname(@AuthenticationPrincipal CustomUserDetails userDetails);
+
+
+    @Operation(summary = "유저의 업적 내용 반환", description = "유저가 달성한 업적들의 내용들을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유저의 업적들 반환 완료",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = AccountBookSpendResponse.class)))),
+            @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없습니다.")
+    })
+    ResponseEntity<List<UserAchievementResponse>> getUserAchievement(@AuthenticationPrincipal CustomUserDetails userDetails);
+
+    @Operation(summary = "유저의 챌린지 정보 반환", description = "유저가 챌린지로 절약한 금액, 성공한 챌린지 수, 참여 중인 챌린지 수, 성공한 챌린지 수를 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유저의 챌린지 정보 반환 완료",
+                    content = @Content(schema = @Schema(implementation = UserChallengeInfoResponse.class))),
+            @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없습니다.")
+    })
+    ResponseEntity<UserChallengeInfoResponse> getUserChallengeInfo(@AuthenticationPrincipal CustomUserDetails userDetails);
 }
 

--- a/src/main/java/dev/book/user/controller/UserSwaggerController.java
+++ b/src/main/java/dev/book/user/controller/UserSwaggerController.java
@@ -14,9 +14,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "User API", description = "유저 프로필 조회, 수정, 유저 삭제 api")
 public interface UserSwaggerController {
@@ -40,7 +38,7 @@ public interface UserSwaggerController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "유저 프로필 수정 완료",
                     content = @Content(schema = @Schema(implementation = UserProfileResponse.class))),
-            @ApiResponse(responseCode = "400", description = "이미 존재하는 닉네임입니다"),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 닉네임입니다"),
             @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없습니다.")
     })
     ResponseEntity<UserProfileResponse> updateUserProfile(@RequestBody UserProfileUpdateRequest profileUpdateRequest,
@@ -62,5 +60,18 @@ public interface UserSwaggerController {
             @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없습니다.")
     })
     ResponseEntity<?> checkIsUserLogin(@AuthenticationPrincipal CustomUserDetails userDetails);
+
+    @Operation(summary = "유저의 닉네임 중복 확인", description = "닉네임의 중복 여부를 체크합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "닉네임 설정 가능"),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 닉네임입니다")
+    })
+    ResponseEntity<Boolean> checkIsValidateNickname(@RequestParam(name = "nickname", required = true) String nickname);
+
+    @Operation(summary = "유저의 닉네임 삭제 (실제 사용 X)", description = "현재 유저의 닉네임을 삭제합니다. \"\" 상태로 저장됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "닉네임 삭제 완료"),
+    })
+    ResponseEntity<?> deleteUserNickname(@AuthenticationPrincipal CustomUserDetails userDetails);
 }
 

--- a/src/main/java/dev/book/user/controller/UserSwaggerController.java
+++ b/src/main/java/dev/book/user/controller/UserSwaggerController.java
@@ -3,6 +3,7 @@ package dev.book.user.controller;
 import dev.book.global.config.security.dto.CustomUserDetails;
 import dev.book.user.dto.request.UserCategoriesRequest;
 import dev.book.user.dto.request.UserProfileUpdateRequest;
+import dev.book.user.dto.response.UserCategoryResponse;
 import dev.book.user.dto.response.UserProfileResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -43,6 +44,13 @@ public interface UserSwaggerController {
     })
     ResponseEntity<UserProfileResponse> updateUserProfile(@RequestBody UserProfileUpdateRequest profileUpdateRequest,
                                                           @AuthenticationPrincipal CustomUserDetails userDetails);
+
+    @Operation(summary = "유저 카테고리 반환", description = "현재 로그인된 유저의 카테고리를 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유저 카테고리 반환 완료"),
+            @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없습니다.")
+    })
+    ResponseEntity<UserCategoryResponse> getUserCategories(@AuthenticationPrincipal CustomUserDetails userDetails);
 
     @Operation(summary = "유저 카테고리 수정", description = "현재 로그인된 유저의 카테고리를 수정합니다.")
     @ApiResponses(value = {

--- a/src/main/java/dev/book/user/dto/response/UserAchievementResponse.java
+++ b/src/main/java/dev/book/user/dto/response/UserAchievementResponse.java
@@ -1,0 +1,6 @@
+package dev.book.user.dto.response;
+
+import java.time.LocalDateTime;
+
+public record UserAchievementResponse(String title, String content, LocalDateTime createdAt) {
+}

--- a/src/main/java/dev/book/user/dto/response/UserCategoryResponse.java
+++ b/src/main/java/dev/book/user/dto/response/UserCategoryResponse.java
@@ -1,0 +1,6 @@
+package dev.book.user.dto.response;
+
+import java.util.List;
+
+public record UserCategoryResponse (List<String> categories){
+}

--- a/src/main/java/dev/book/user/dto/response/UserChallengeInfoResponse.java
+++ b/src/main/java/dev/book/user/dto/response/UserChallengeInfoResponse.java
@@ -1,0 +1,4 @@
+package dev.book.user.dto.response;
+
+public record UserChallengeInfoResponse(long savings, int completedChallenges, int participatingChallenges, int finishedChallenge) {
+}

--- a/src/main/java/dev/book/user/entity/UserEntity.java
+++ b/src/main/java/dev/book/user/entity/UserEntity.java
@@ -43,6 +43,8 @@ public class UserEntity extends BaseTimeEntity {
 
     private int participatingChallenges = 0;
 
+    private int finishedChallenge = 0;
+
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserCategory> userCategory = new ArrayList<>();
 
@@ -115,6 +117,18 @@ public class UserEntity extends BaseTimeEntity {
 
     public void minusChallengeCount() {
         this.participatingChallenges--;
+    }
+
+    public void plusCompleteChallenge(){
+        this.completedChallenges++;
+    }
+
+    public void plusSavings(long plusSavings){
+        this.savings += plusSavings;
+    }
+
+    public void plusFinishedChallenge(){
+        this.finishedChallenge++;
     }
 
 }

--- a/src/main/java/dev/book/user/entity/UserEntity.java
+++ b/src/main/java/dev/book/user/entity/UserEntity.java
@@ -1,5 +1,6 @@
 package dev.book.user.entity;
 
+import dev.book.achievement.achievement_user.entity.AchievementUser;
 import dev.book.challenge.user_challenge.entity.UserChallenge;
 import dev.book.global.config.security.dto.oauth2.OAuth2Attributes;
 import dev.book.global.entity.BaseTimeEntity;
@@ -54,6 +55,8 @@ public class UserEntity extends BaseTimeEntity {
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserChallenge> userChallenges = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<AchievementUser> achievements = new ArrayList<>();
 
     //todo 알림 설정 필요
     //todo 이후 entity과의 관계 설정 필요

--- a/src/main/java/dev/book/user/entity/UserEntity.java
+++ b/src/main/java/dev/book/user/entity/UserEntity.java
@@ -111,11 +111,11 @@ public class UserEntity extends BaseTimeEntity {
 
     public void deleteNickname() { this.nickname = ""; }
 
-    public void plusChallengeCount() {
+    public void plusParticipatingChallenge() {
         this.participatingChallenges++;
     }
 
-    public void minusChallengeCount() {
+    public void minusParticipatingChallenge() {
         this.participatingChallenges--;
     }
 

--- a/src/main/java/dev/book/user/entity/UserEntity.java
+++ b/src/main/java/dev/book/user/entity/UserEntity.java
@@ -99,4 +99,6 @@ public class UserEntity extends BaseTimeEntity {
         this.profileImageUrl = profileImageUrl;
     }
 
+    public void deleteNickname() { this.nickname = ""; }
+
 }

--- a/src/main/java/dev/book/user/exception/UserErrorCode.java
+++ b/src/main/java/dev/book/user/exception/UserErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
-    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다"),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
     FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, "친구 유저를 찾을 수 없습니다."),
     INVITING_NOT_FOUND(HttpStatus.NOT_FOUND, "초대 토큰과 알맞는 내역을 찾을 수 없습니다.");

--- a/src/main/java/dev/book/user/exception/UserErrorCode.java
+++ b/src/main/java/dev/book/user/exception/UserErrorCode.java
@@ -9,9 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다"),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
-    FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, "친구 유저를 찾을 수 없습니다."),
-    INVITING_NOT_FOUND(HttpStatus.NOT_FOUND, "초대 토큰과 알맞는 내역을 찾을 수 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/dev/book/user/repository/UserRepository.java
+++ b/src/main/java/dev/book/user/repository/UserRepository.java
@@ -2,6 +2,8 @@ package dev.book.user.repository;
 
 import dev.book.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -9,6 +11,14 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByEmail(String email);
+
+    @Query("""
+        SELECT u FROM UserEntity u
+        JOIN FETCH u.userCategory uc
+        JOIN FETCH uc.category
+        WHERE u.email = :email
+    """)
+    Optional<UserEntity> findByEmailWithCategories(@Param("email") String email);
 
     boolean existsByNickname(String nickname);
 }

--- a/src/main/java/dev/book/user/service/UserService.java
+++ b/src/main/java/dev/book/user/service/UserService.java
@@ -97,14 +97,26 @@ public class UserService {
         user.updateCategory(categoryList);
     }
 
+    /**
+     * 유저의 로그인 상태를 true로 변경
+     * @param userDetails
+     */
     public void checkIsUserLogin(CustomUserDetails userDetails) {
         individualAchievementStatusService.deterMineContinuousLogin(userDetails.user());
     }
 
+    /**
+     * nickname 중복 체크 (중복이라면 409에러 반환)
+     * @param nickname
+     */
     public void checkIsValidateNickname(String nickname) {
         validateNickname(nickname);
     }
 
+    /**
+     * 유저의 닉네임 삭제
+     * @param userDetails
+     */
     @Transactional
     public void deleteUserNickname(CustomUserDetails userDetails) {
         UserEntity user = userRepository.findByEmail(userDetails.getUsername())
@@ -112,6 +124,11 @@ public class UserService {
         user.deleteNickname();
     }
 
+    /**
+     * 유저의 카테고리 반환
+     * @param userDetails
+     * @return
+     */
     public UserCategoryResponse getUserCategories(CustomUserDetails userDetails) {
         UserEntity user = userRepository.findByEmailWithCategories(userDetails.getUsername())
                 .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_NOT_FOUND));

--- a/src/main/java/dev/book/user/service/UserService.java
+++ b/src/main/java/dev/book/user/service/UserService.java
@@ -14,6 +14,7 @@ import dev.book.user.dto.request.UserCategoriesRequest;
 import dev.book.user.dto.request.UserProfileUpdateRequest;
 import dev.book.user.dto.response.UserAchievementResponse;
 import dev.book.user.dto.response.UserCategoryResponse;
+import dev.book.user.dto.response.UserChallengeInfoResponse;
 import dev.book.user.dto.response.UserProfileResponse;
 import dev.book.user.entity.UserEntity;
 import dev.book.user.exception.UserErrorCode;
@@ -130,5 +131,11 @@ public class UserService {
                                 achievementUser.getAchievement().getContent(),
                                 achievementUser.getCreatedAt()
                 )).toList();
+    }
+
+    public UserChallengeInfoResponse getUserChallengeInfo(CustomUserDetails userDetails) {
+        UserEntity user = userDetails.user();
+        return new UserChallengeInfoResponse(user.getSavings(), user.getCompletedChallenges(),
+                user.getParticipatingChallenges(), user.getFinishedChallenge());
     }
 }

--- a/src/main/java/dev/book/user/service/UserService.java
+++ b/src/main/java/dev/book/user/service/UserService.java
@@ -1,6 +1,8 @@
 package dev.book.user.service;
 
 import dev.book.achievement.achievement_user.IndividualAchievementStatusService;
+import dev.book.achievement.achievement_user.entity.AchievementUser;
+import dev.book.achievement.achievement_user.repository.AchievementUserRepository;
 import dev.book.global.config.security.dto.CustomUserDetails;
 import dev.book.global.config.security.jwt.JwtUtil;
 import dev.book.global.config.security.service.refresh.RefreshTokenService;
@@ -10,6 +12,7 @@ import dev.book.global.exception.category.CategoryException;
 import dev.book.global.repository.CategoryRepository;
 import dev.book.user.dto.request.UserCategoriesRequest;
 import dev.book.user.dto.request.UserProfileUpdateRequest;
+import dev.book.user.dto.response.UserAchievementResponse;
 import dev.book.user.dto.response.UserCategoryResponse;
 import dev.book.user.dto.response.UserProfileResponse;
 import dev.book.user.entity.UserEntity;
@@ -32,6 +35,8 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final CategoryRepository categoryRepository;
+    private final AchievementUserRepository achievementUserRepository;
+
     private final RefreshTokenService refreshTokenService;
     private final IndividualAchievementStatusService individualAchievementStatusService;
     private final JwtUtil jwtUtil;
@@ -115,5 +120,15 @@ public class UserService {
             userCategories.add(category.getCategory().getKorean());
         }
         return new UserCategoryResponse(userCategories);
+    }
+
+    public List<UserAchievementResponse> getUserAchievement(CustomUserDetails userDetails) {
+        List<AchievementUser> achievementUsers = achievementUserRepository.findAllByUser(userDetails.user());
+        return achievementUsers.stream().map(
+                achievementUser -> new UserAchievementResponse(
+                                achievementUser.getAchievement().getTitle(),
+                                achievementUser.getAchievement().getContent(),
+                                achievementUser.getCreatedAt()
+                )).toList();
     }
 }

--- a/src/main/java/dev/book/user/service/UserService.java
+++ b/src/main/java/dev/book/user/service/UserService.java
@@ -42,10 +42,10 @@ public class UserService {
 
         validateNickname(profileUpdateRequest.nickname());
 
-        UserEntity user = userDetails.user();
+        UserEntity user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_NOT_FOUND));
         user.updateNickname(profileUpdateRequest.nickname());
         user.updateProfileImage(profileUpdateRequest.profileImageUrl());
-        userRepository.save(user);
         return UserProfileResponse.fromEntity(user);
     }
 
@@ -63,10 +63,10 @@ public class UserService {
      */
     @Transactional
     public void deleteUser(HttpServletRequest request, HttpServletResponse response, CustomUserDetails userDetails) {
-        jwtUtil.deleteAccessTokenAndRefreshToken(request, response);
         UserEntity user = userDetails.user();
         refreshTokenService.deleteRefreshToken(user);
         userRepository.delete(user);
+        jwtUtil.deleteAccessTokenAndRefreshToken(request, response);
     }
 
     /**
@@ -90,5 +90,16 @@ public class UserService {
 
     public void checkIsUserLogin(CustomUserDetails userDetails) {
         individualAchievementStatusService.deterMineContinuous(userDetails.user());
+    }
+
+    public void checkIsValidateNickname(String nickname) {
+        validateNickname(nickname);
+    }
+
+    @Transactional
+    public void deleteUserNickname(CustomUserDetails userDetails) {
+        UserEntity user = userRepository.findByEmail(userDetails.getUsername())
+                        .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_NOT_FOUND));
+        user.deleteNickname();
     }
 }

--- a/src/main/java/dev/book/user/service/UserService.java
+++ b/src/main/java/dev/book/user/service/UserService.java
@@ -10,17 +10,20 @@ import dev.book.global.exception.category.CategoryException;
 import dev.book.global.repository.CategoryRepository;
 import dev.book.user.dto.request.UserCategoriesRequest;
 import dev.book.user.dto.request.UserProfileUpdateRequest;
+import dev.book.user.dto.response.UserCategoryResponse;
 import dev.book.user.dto.response.UserProfileResponse;
 import dev.book.user.entity.UserEntity;
 import dev.book.user.exception.UserErrorCode;
 import dev.book.user.exception.UserErrorException;
 import dev.book.user.repository.UserRepository;
+import dev.book.user.user_category.UserCategory;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -101,5 +104,16 @@ public class UserService {
         UserEntity user = userRepository.findByEmail(userDetails.getUsername())
                         .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_NOT_FOUND));
         user.deleteNickname();
+    }
+
+    public UserCategoryResponse getUserCategories(CustomUserDetails userDetails) {
+        UserEntity user = userRepository.findByEmailWithCategories(userDetails.getUsername())
+                .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_NOT_FOUND));
+        List<UserCategory> categories = user.getUserCategory();
+        List<String> userCategories = new ArrayList<>();
+        for (UserCategory category : categories){
+            userCategories.add(category.getCategory().getKorean());
+        }
+        return new UserCategoryResponse(userCategories);
     }
 }

--- a/src/main/java/dev/book/user/user_friend/controller/UserFriendSwaggerController.java
+++ b/src/main/java/dev/book/user/user_friend/controller/UserFriendSwaggerController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
-@Tag(name = "친구 API", description = "친구 초대 토큰 발급, 친구 조회, 삭제 api")
+@Tag(name = "친구 API", description = "친구 초대 토큰 발급, 친구 조회, 친구 요청 관리, 삭제 api")
 public interface UserFriendSwaggerController {
 
     @Operation(summary = "친구 초대 토큰 발급", description = "`카카오톡 공유하기` 전 친구 초대 토큰을 발급 후 포함하여 `공유하기`를 보냅니다.")

--- a/src/main/java/dev/book/user/user_friend/exception/UserFriendErrorCode.java
+++ b/src/main/java/dev/book/user/user_friend/exception/UserFriendErrorCode.java
@@ -12,7 +12,7 @@ public enum UserFriendErrorCode implements ErrorCode {
     FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, "친구 유저를 찾을 수 없습니다."),
     INVITING_NOT_FOUND(HttpStatus.NOT_FOUND, "초대 토큰과 알맞는 내역을 찾을 수 없습니다."),
     DUPLICATE_INVITATION(HttpStatus.CONFLICT, "이미 존재하는 초대 요청입니다."),
-    ALREADY_MAKE_INVITATION(HttpStatus.BAD_REQUEST, "이미 초대 요청이 만들어진 상태입니다"),
+    ALREADY_MADE_INVITATION(HttpStatus.BAD_REQUEST, "이미 초대 요청이 만들어진 상태입니다"),
     MYSELF_INVITATION(HttpStatus.BAD_REQUEST, "내가 나에게 초대 요청을 보낼 수 없습니다."),
     FRIEND_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "친구의 요청을 찾을 수 없습니다.");
 

--- a/src/main/java/dev/book/user/user_friend/exception/UserFriendErrorCode.java
+++ b/src/main/java/dev/book/user/user_friend/exception/UserFriendErrorCode.java
@@ -8,8 +8,13 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserFriendErrorCode implements ErrorCode {
-    FRIEND_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "친구의 요청을 찾을 수 없습니다."),
-    FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, "친구를 찾을 수 없습니다.");
+
+    FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, "친구 유저를 찾을 수 없습니다."),
+    INVITING_NOT_FOUND(HttpStatus.NOT_FOUND, "초대 토큰과 알맞는 내역을 찾을 수 없습니다."),
+    DUPLICATE_INVITATION(HttpStatus.CONFLICT, "이미 존재하는 초대 요청입니다."),
+    ALREADY_MAKE_INVITATION(HttpStatus.BAD_REQUEST, "이미 초대 요청이 만들어진 상태입니다"),
+    MYSELF_INVITATION(HttpStatus.BAD_REQUEST, "내가 나에게 초대 요청을 보낼 수 없습니다."),
+    FRIEND_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "친구의 요청을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/dev/book/user/user_friend/repository/UserFriendRepository.java
+++ b/src/main/java/dev/book/user/user_friend/repository/UserFriendRepository.java
@@ -29,4 +29,6 @@ public interface UserFriendRepository extends JpaRepository<UserFriend, Long> {
 
     @Modifying
     void deleteByUserAndFriendAndIsAcceptIsTrue(UserEntity user, UserEntity friend);
+
+    boolean existsByUserAndRequestedAt(UserEntity invitingUser, LocalDateTime localDateTime);
 }

--- a/src/main/java/dev/book/user/user_friend/service/UserFriendService.java
+++ b/src/main/java/dev/book/user/user_friend/service/UserFriendService.java
@@ -81,7 +81,7 @@ public class UserFriendService {
         //내가 나 자신에게 친구 요청
         invitationMyself(userFriend.getUser(), email);
         //이미 초대 내역이 완성된 토큰
-        hasExistingInvitation(userFriend.getFriend() != null, UserFriendErrorCode.ALREADY_MAKE_INVITATION);
+        hasExistingInvitation(userFriend.getFriend() != null, UserFriendErrorCode.ALREADY_MADE_INVITATION);
 
         UserEntity friend = getUserEntity(userRepository.findByEmail(email));
         userFriend.inviteFriend(friend);

--- a/src/test/java/dev/book/user/service/UserServiceUnitTest.java
+++ b/src/test/java/dev/book/user/service/UserServiceUnitTest.java
@@ -1,9 +1,19 @@
 package dev.book.user.service;
 
+import dev.book.achievement.achievement_user.entity.AchievementUser;
+import dev.book.achievement.achievement_user.repository.AchievementUserRepository;
+import dev.book.achievement.entity.Achievement;
 import dev.book.global.config.security.dto.CustomUserDetails;
 import dev.book.global.config.security.jwt.JwtAuthenticationToken;
 import dev.book.global.config.security.jwt.JwtUtil;
+import dev.book.global.entity.Category;
+import dev.book.global.exception.category.CategoryException;
+import dev.book.global.repository.CategoryRepository;
+import dev.book.user.dto.request.UserCategoriesRequest;
 import dev.book.user.dto.request.UserProfileUpdateRequest;
+import dev.book.user.dto.response.UserAchievementResponse;
+import dev.book.user.dto.response.UserCategoryResponse;
+import dev.book.user.dto.response.UserChallengeInfoResponse;
 import dev.book.user.dto.response.UserProfileResponse;
 import dev.book.user.entity.UserEntity;
 import dev.book.user.exception.UserErrorCode;
@@ -21,6 +31,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.util.List;
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -35,6 +48,12 @@ class UserServiceUnitTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private AchievementUserRepository achievementUserRepository;
 
     @Mock
     private HttpServletRequest request;
@@ -131,4 +150,100 @@ class UserServiceUnitTest {
         assertThatThrownBy(() -> userService.deleteUser(request, response, null))
                 .isInstanceOf(NullPointerException.class);
     }
+
+    @Test
+    @DisplayName("유저의 카테고리를 변경한다.")
+    void changeCategories(){
+        //given
+        given(userRepository.findByEmail(any())).willReturn(Optional.ofNullable(userDetails.user()));
+        List<String> categories = List.of("food", "cafe_snack");
+        List<Category> categoryList = List.of(new Category("food", "음식"), new Category("cafe_snack", "카페 / 간식") );
+        given(categoryRepository.findByCategoryIn(categories)).willReturn(categoryList);
+        UserCategoriesRequest categoriesRequest = new UserCategoriesRequest(categories);
+
+        //when
+        userService.updateUserCategories(categoriesRequest, userDetails);
+
+        //then
+        assertThat(userDetails.user().getUserCategory().size()).isEqualTo(2);
+
+    }
+
+    @Test
+    @DisplayName("카테고리 내역이 없다면 에러를 반환한다.")
+    void checkCategories(){
+        //given
+        given(userRepository.findByEmail(any())).willReturn(Optional.ofNullable(userDetails.user()));
+        List<String> categories = List.of("food", "cafe", "snack");
+        List<Category> categoryList = List.of(new Category("food", "음식"));
+        given(categoryRepository.findByCategoryIn(categories)).willReturn(categoryList);
+        UserCategoriesRequest categoriesRequest = new UserCategoriesRequest(categories);
+
+        //when & then
+        assertThatThrownBy(() -> userService.updateUserCategories(categoriesRequest, userDetails))
+                .isInstanceOf(CategoryException.class)
+                        .hasMessageContaining("일치하지 않는 카테고리가 존재합니다.");
+
+    }
+
+    @Test
+    @DisplayName("유저의 카테고리를 반환한다.")
+    void getUserCategories(){
+        //given
+        UserEntity user = UserBuilder.withCategory(); // food, cafe_snack 으로 초기화
+        userDetails = new CustomUserDetails(user);
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(userDetails, userDetails.getAuthorities()));
+
+        given(userRepository.findByEmailWithCategories(any())).willReturn(Optional.ofNullable(userDetails.user()));
+
+        //when
+        UserCategoryResponse userCategoryResponse = userService.getUserCategories(userDetails);
+
+        //then
+        assertThat(userCategoryResponse.categories().size()).isEqualTo(2);
+        assertThat(userCategoryResponse.categories().contains("음식")).isTrue();
+        assertThat(userCategoryResponse.categories().contains("카페 / 간식")).isTrue();
+    }
+
+    @Test
+    @DisplayName("유저의 업적들을 반환한다.")
+    void getUserAchievement(){
+        //given
+        UserEntity user = userDetails.user();
+        Achievement achievement = new Achievement("업적", "내용");
+        AchievementUser achievementUser = new AchievementUser(user, achievement);
+        given(achievementUserRepository.findAllByUser(user)).willReturn(List.of(achievementUser));
+
+        //when
+        List<UserAchievementResponse> userAchievementResponses = userService.getUserAchievement(userDetails);
+
+        //then
+        assertThat(userAchievementResponses.size()).isEqualTo(1);
+        assertThat(userAchievementResponses.get(0).title()).isEqualTo(achievement.getTitle());
+        assertThat(userAchievementResponses.get(0).content()).isEqualTo(achievement.getContent());
+    }
+
+    @Test
+    @DisplayName("유저의 챌린지 내용을 반환한다.")
+    void getUserChallenge(){
+        //given
+        UserEntity user = userDetails.user();
+        user.plusSavings(10000L);
+        user.plusFinishedChallenge();
+        user.plusCompleteChallenge();
+        user.plusParticipatingChallenge();
+
+        //when
+        UserChallengeInfoResponse userChallengeInfoResponse = userService.getUserChallengeInfo(userDetails);
+
+        //then
+        assertThat(userChallengeInfoResponse.savings()).isEqualTo(user.getSavings());
+        assertThat(userChallengeInfoResponse.finishedChallenge()).isEqualTo(user.getFinishedChallenge());
+        assertThat(userChallengeInfoResponse.completedChallenges()).isEqualTo(user.getCompletedChallenges());
+        assertThat(userChallengeInfoResponse.participatingChallenges()).isEqualTo(user.getParticipatingChallenges());
+
+    }
+
+
+
 }

--- a/src/test/java/dev/book/user/user_friend/service/UserFriendServiceUnitTest.java
+++ b/src/test/java/dev/book/user/user_friend/service/UserFriendServiceUnitTest.java
@@ -65,7 +65,6 @@ class UserFriendServiceUnitTest {
     @InjectMocks
     UserFriendService userFriendService;
 
-    @Spy
     @InjectMocks
     AESUtil aesUtil;
 
@@ -165,14 +164,17 @@ class UserFriendServiceUnitTest {
         EncryptUserInfo encryptUserInfo = new EncryptUserInfo(userDetails.getUsername(), 1L, LocalDateTime.of(2025, 4, 21, 14, 29, 54));
         InvitingTokenAndJson invitingTokenAndJson = getInvitingTokenAndJson();
 
+        UserFriend userFriend = mock(UserFriend.class);
+        given(userFriend.getUser()).willReturn(userDetails.user());
+        given(userFriend.getFriend()).willReturn(null);  // 아직 초대되지 않은 상태
+
         //토큰 받은 유저
         UserEntity invitedUser = UserBuilder.of("test2@test.com");
         userDetails = new CustomUserDetails(invitedUser);
         SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(userDetails, userDetails.getAuthorities()));
 
-        UserFriend userFriend = mock(UserFriend.class);
         given(objectMapper.readValue(eq(invitingTokenAndJson.jsonToken()), eq(EncryptUserInfo.class))).willReturn(encryptUserInfo);
-        given(userFriendRepository.findByInvitingUserAndRequestedAt(any(), any())).willReturn(Optional.ofNullable(userFriend));
+        given(userFriendRepository.findByInvitingUserAndRequestedAt(any(), any())).willReturn(Optional.of(userFriend));
         given(userRepository.findByEmail(invitedUser.getEmail())).willReturn(Optional.of(invitedUser));
 
         //when

--- a/src/test/java/dev/book/user/user_friend/service/UserFriendServiceUnitTest.java
+++ b/src/test/java/dev/book/user/user_friend/service/UserFriendServiceUnitTest.java
@@ -1,0 +1,249 @@
+package dev.book.user.user_friend.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import dev.book.achievement.achievement_user.dto.event.InviteFriendToServiceEvent;
+import dev.book.global.config.security.dto.CustomUserDetails;
+import dev.book.global.config.security.jwt.JwtAuthenticationToken;
+import dev.book.user.entity.UserEntity;
+import dev.book.user.repository.UserRepository;
+import dev.book.user.user_friend.dto.EncryptUserInfo;
+import dev.book.user.user_friend.dto.response.FriendListResponseDto;
+import dev.book.user.user_friend.dto.response.FriendRequestListResponseDto;
+import dev.book.user.user_friend.dto.response.InvitingUserTokenResponseDto;
+import dev.book.user.user_friend.dto.response.KakaoResponseDto;
+import dev.book.user.user_friend.entity.UserFriend;
+import dev.book.user.user_friend.repository.UserFriendRepository;
+import dev.book.user.user_friend.util.AESUtil;
+import dev.book.util.UserBuilder;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserFriendServiceUnitTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserFriendRepository userFriendRepository;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    UserFriendService userFriendService;
+
+    @Spy
+    @InjectMocks
+    AESUtil aesUtil;
+
+    CustomUserDetails userDetails;
+
+    @BeforeEach
+    public void createUser(){
+        UserEntity user = UserBuilder.of();
+        userDetails = new CustomUserDetails(user);
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(userDetails, userDetails.getAuthorities()));
+    }
+
+    @BeforeEach
+    void setUp(){
+        objectMapper.registerModule(new JavaTimeModule());
+        ReflectionTestUtils.setField(aesUtil, "SECRET_KEY", "abcdefghijklmnopqrstuvwxyzabcdef");
+    }
+
+    @Test
+    @DisplayName("유저 초대 토큰을 생성한다.")
+    void getInviteUserToken() throws Exception {
+        //given
+        String jsonToken = makeJsonTokenFromEncryptUserInfo();
+        given(objectMapper.writeValueAsString(any(EncryptUserInfo.class))).willReturn(jsonToken);
+
+        //when
+        InvitingUserTokenResponseDto invitingUserTokenResponseDto = userFriendService.getInviteUserToken(userDetails);
+
+        //then
+        assertThat(invitingUserTokenResponseDto).isNotNull();
+    }
+
+    private String makeJsonTokenFromEncryptUserInfo() throws JsonProcessingException {
+        EncryptUserInfo encryptUserInfo = new EncryptUserInfo(userDetails.getUsername(), 1L, LocalDateTime.of(2025, 4, 21, 14, 29, 54));
+        ObjectMapper newObjectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        return newObjectMapper.writeValueAsString(encryptUserInfo);
+    }
+
+    @NotNull
+    private InvitingTokenAndJson getInvitingTokenAndJson() throws Exception {
+        String jsonToken = makeJsonTokenFromEncryptUserInfo();
+        given(objectMapper.writeValueAsString(any(EncryptUserInfo.class))).willReturn(jsonToken);
+        InvitingUserTokenResponseDto invitingUserTokenResponseDto = userFriendService.getInviteUserToken(userDetails);
+        return new InvitingTokenAndJson(jsonToken, invitingUserTokenResponseDto);
+    }
+
+    private record InvitingTokenAndJson(String jsonToken, InvitingUserTokenResponseDto invitingUserTokenResponseDto) {
+    }
+
+    @Test
+    @DisplayName("공유하기를 성공했을 때 카카오 서버에서 오는 웹훅으로 초대 내역을 생성한다.")
+    void getWebHookFromKakao() throws Exception {
+        //given
+        //토큰 생성
+        EncryptUserInfo encryptUserInfo = new EncryptUserInfo(userDetails.getUsername(), null, LocalDateTime.of(2025, 4, 21, 14, 29, 54));
+        InvitingTokenAndJson invitingTokenAndJson = getInvitingTokenAndJson();
+
+        given(objectMapper.readValue(eq(invitingTokenAndJson.jsonToken()), eq(EncryptUserInfo.class))).willReturn(encryptUserInfo);
+        given(userRepository.findById(any())).willReturn(Optional.ofNullable(userDetails.user()));
+
+        //when, 사전에 생성한 토큰으로 받은 웹훅
+        KakaoResponseDto kakaoResponseDto = new KakaoResponseDto("chat", 1000L, "hash", invitingTokenAndJson.invitingUserTokenResponseDto().invitingUserToken());
+        userFriendService.getWebHookFromKakao(kakaoResponseDto);
+
+        //then
+        verify(userFriendRepository).save(argThat(userFriend ->
+                userFriend.getUser().equals(userDetails.user()) &&
+                userFriend.getRequestedAt().equals(encryptUserInfo.localDateTime())));
+    }
+
+    @Test
+    @WithMockUser("test@test.com")
+    @DisplayName("초대 토큰을 받아 초대 내역을 완성한다.")
+    void getTokenAndMakeInvitation() throws Exception {
+        //given
+        //초대 토큰 생성
+        EncryptUserInfo encryptUserInfo = new EncryptUserInfo(userDetails.getUsername(), 1L, LocalDateTime.of(2025, 4, 21, 14, 29, 54));
+        InvitingTokenAndJson invitingTokenAndJson = getInvitingTokenAndJson();
+
+        //토큰 받은 유저
+        UserEntity invitedUser = UserBuilder.of("test2@test.com");
+        userDetails = new CustomUserDetails(invitedUser);
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(userDetails, userDetails.getAuthorities()));
+
+        UserFriend userFriend = mock(UserFriend.class);
+        given(objectMapper.readValue(eq(invitingTokenAndJson.jsonToken()), eq(EncryptUserInfo.class))).willReturn(encryptUserInfo);
+        given(userFriendRepository.findByInvitingUserAndRequestedAt(any(), any())).willReturn(Optional.ofNullable(userFriend));
+        given(userRepository.findByEmail(invitedUser.getEmail())).willReturn(Optional.of(invitedUser));
+
+        //when
+        userFriendService.getTokenAndMakeInvitation(userDetails, response, invitingTokenAndJson.invitingUserTokenResponseDto.invitingUserToken());
+
+        //then
+        verify(userFriend).inviteFriend(invitedUser);
+        verify(eventPublisher).publishEvent(any(InviteFriendToServiceEvent.class));
+    }
+
+
+    @Test
+    @DisplayName("친구 요청 내역을 반환한다.")
+    void getFriendRequestList() {
+        //given
+        //토큰을 만들어서 보낸 유저 (초대한 유저)
+        UserEntity invitingUser = UserBuilder.of("test2@test.com");
+        given(userFriendRepository.findAllByInvitedUserAndIsRequestIsTrue(any())).willReturn(List.of(invitingUser));
+
+        //when
+        List<FriendRequestListResponseDto> requestListResponseDtos = userFriendService.getFriendRequestList(userDetails);
+
+        //then
+        assertThat(requestListResponseDtos.size()).isEqualTo(1);
+        assertThat(requestListResponseDtos.get(0).email()).isEqualTo(invitingUser.getEmail());
+
+        verify(userFriendRepository).findAllByInvitedUserAndIsRequestIsTrue(any());
+    }
+
+    @Test
+    @DisplayName("친구 요청을 승낙한다.")
+    void acceptFriend() {
+        //given
+        UserEntity invitingUser = UserBuilder.of("test2@test.com");
+        given(userRepository.findById(any())).willReturn(Optional.ofNullable(invitingUser));
+
+        UserFriend userFriend = mock(UserFriend.class);
+        given(userFriendRepository.findByUserAndFriendAndIsRequestIsTrue(invitingUser, userDetails.user())).willReturn(Optional.ofNullable(userFriend));
+
+        //when
+        userFriendService.acceptFriend(userDetails, any());
+
+        //then
+        verify(userFriend).accept();
+    }
+
+    @Test
+    @DisplayName("친구 목록을 반환한다.")
+    void getFriendList() {
+        //given
+        //토큰을 만들어서 보낸 유저 (초대한 유저)
+        UserEntity invitingUser = UserBuilder.of("test2@test.com");
+        given(userFriendRepository.findAllByInvitedUserAndIsAcceptIsTrue(any())).willReturn(List.of(invitingUser));
+
+        //when
+        List<FriendListResponseDto> friendListResponseDtos = userFriendService.getFriendList(userDetails);
+
+        //then
+        assertThat(friendListResponseDtos.size()).isEqualTo(1);
+        assertThat(friendListResponseDtos.get(0).name()).isEqualTo(invitingUser.getName());
+
+        verify(userFriendRepository).findAllByInvitedUserAndIsAcceptIsTrue(any());
+    }
+
+    @Test
+    @DisplayName("친구 요청을 거절한다.")
+    void rejectFriend() {
+        //given
+        UserEntity invitingUser = UserBuilder.of("test2@test.com");
+        given(userRepository.findById(any())).willReturn(Optional.ofNullable(invitingUser));
+
+        UserFriend userFriend = mock(UserFriend.class);
+        given(userFriendRepository.findByUserAndFriendAndIsRequestIsTrue(invitingUser, userDetails.user())).willReturn(Optional.ofNullable(userFriend));
+
+        //when
+        userFriendService.rejectFriend(userDetails, any());
+
+        //then
+        verify(userFriendRepository).delete(any(UserFriend.class));
+    }
+
+    @Test
+    @DisplayName("친구를 삭제한다.")
+    void deleteFriend() {
+        //given
+        UserEntity friend = UserBuilder.of("test2@test.com");
+        given(userRepository.findById(any())).willReturn(Optional.ofNullable(friend));
+
+        //when
+        userFriendService.deleteFriend(userDetails, any());
+
+        //then
+        verify(userFriendRepository).deleteByUserAndFriendAndIsAcceptIsTrue(userDetails.user(), friend);
+        verify(userFriendRepository).deleteByUserAndFriendAndIsAcceptIsTrue(friend, userDetails.user());
+    }
+}

--- a/src/test/java/dev/book/util/UserBuilder.java
+++ b/src/test/java/dev/book/util/UserBuilder.java
@@ -1,7 +1,10 @@
 package dev.book.util;
 
+import dev.book.global.entity.Category;
 import dev.book.user.entity.UserEntity;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class UserBuilder {
@@ -15,6 +18,9 @@ public class UserBuilder {
     private static String name = NAME;
     private static String nickname = NICKNAME;
     private static String profileImageUrl = PROFILE_IMAGE_URL;
+    private static List<Category> categoryList
+            = List.of(new Category("food", "음식"), new Category("cafe_snack", "카페 / 간식") );
+
 
     public static UserEntity of() {
         return UserEntity.builder()
@@ -40,6 +46,12 @@ public class UserBuilder {
                 .name(name)
                 .profileImageUrl(profileImageUrl)
                 .build();
+    }
+
+    public static UserEntity withCategory(){
+        UserEntity user = UserBuilder.of();
+        user.updateCategory(categoryList);
+        return user;
     }
 
     public static UserEntity newUser(String email, String name){


### PR DESCRIPTION
## 설명

1. 프론트 측에서 요구한 닉네임 중복 기능 + 닉네임 삭제 기능 추가
2. 유저 기능 추가 (마이페이지 업적 반환, 챌린지 현황 반환)
3. UserFriend 관련 에러 처리 (중복 초대, 내가 나에게 초대, 이미 친구인 상황)

쿠키는 현재 http 연결이기 때문에 secure, samesite 설정에 대해 주석 처리 해놓았습니다. 이후 https 연결이 되면 해제하겠습니다!
userEntity 삭제에 대해서 지금 다양한 연관관계가 걸려있어서.. UserEntity에 OneToMany 설정해주시면 감사하겟습니다.

현재 통합 테스트까지 진행하기엔 빠듯할 것 같아 우선적으로 단위 테스트만 진행하였습니다.

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
## 이슈 번호
#58 #24 #40 
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
