### PR TITLE
76 feature 매일 계좌 동기화

### DIFF
--- a/src/main/java/dev/book/accountbook/controller/AccountBookController.java
+++ b/src/main/java/dev/book/accountbook/controller/AccountBookController.java
@@ -2,10 +2,7 @@ package dev.book.accountbook.controller;
 
 import dev.book.accountbook.controller.swagger.AccountBookApi;
 import dev.book.accountbook.dto.request.*;
-import dev.book.accountbook.dto.response.AccountBookIncomeResponse;
-import dev.book.accountbook.dto.response.AccountBookMonthResponse;
-import dev.book.accountbook.dto.response.AccountBookPeriodResponse;
-import dev.book.accountbook.dto.response.AccountBookSpendResponse;
+import dev.book.accountbook.dto.response.*;
 import dev.book.accountbook.service.AccountBookService;
 import dev.book.global.config.security.dto.CustomUserDetails;
 import dev.book.user.entity.UserEntity;
@@ -15,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -123,18 +121,10 @@ public class AccountBookController implements AccountBookApi {
     }
 
     @Override
-    @PostMapping("/spend-list")
-    public ResponseEntity<List<AccountBookSpendResponse>> createSpendList(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody AccountBookSpendListRequest requestList) {
-        List<AccountBookSpendResponse> spendList = accountBookService.createSpendList(userDetails.user(), requestList);
-
-        return ResponseEntity.ok(spendList);
-    }
-
-    @Override
-    @PostMapping("/all")
-    public ResponseEntity<List<AccountBookPeriodResponse>> getAccountBookPeriod(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody AccountBookListRequest request) {
+    @GetMapping("/all")
+    public ResponseEntity<List<AccountBookPeriodResponse>> getAccountBookPeriod(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestParam LocalDate startDate, @RequestParam LocalDate endDate) {
         Long userId = userDetails.user().getId();
-        List<AccountBookPeriodResponse> responseList = accountBookService.getAccountBookPeriod(userId, request);
+        List<AccountBookPeriodResponse> responseList = accountBookService.getAccountBookPeriod(userId, startDate, endDate);
 
         return ResponseEntity.ok(responseList);
     }
@@ -146,5 +136,22 @@ public class AccountBookController implements AccountBookApi {
         List<AccountBookMonthResponse> responseList = accountBookService.getMonthAccountBook(userId, request);
 
         return ResponseEntity.ok(responseList);
+    }
+
+    @Override
+    @PostMapping("/spend-list")
+    public ResponseEntity<List<AccountBookSpendResponse>> createSpendList(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody AccountBookSpendListRequest requestList) {
+        List<AccountBookSpendResponse> spendList = accountBookService.createSpendList(userDetails.user(), requestList);
+
+        return ResponseEntity.ok(spendList);
+    }
+
+    @Override
+    @GetMapping("/temp-list")
+    public ResponseEntity<List<TempAccountBookResponse>> getTempAccountBook(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.user().getId();
+        List<TempAccountBookResponse> tempList = accountBookService.getTempList(userId);
+
+        return ResponseEntity.ok(tempList);
     }
 }

--- a/src/main/java/dev/book/accountbook/controller/CodefController.java
+++ b/src/main/java/dev/book/accountbook/controller/CodefController.java
@@ -2,6 +2,7 @@ package dev.book.accountbook.controller;
 
 import dev.book.accountbook.controller.swagger.CodefApi;
 import dev.book.accountbook.dto.request.CreateConnectedIdRequest;
+import dev.book.accountbook.entity.TempAccountBook;
 import dev.book.accountbook.service.CodefService;
 import dev.book.global.config.security.dto.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/codef")
@@ -33,9 +36,10 @@ public class CodefController implements CodefApi {
     }
 
     @Override
+    @Profile("local")
     @GetMapping("/trans")
-    public ResponseEntity<String> trans(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        String decodeList = codefService.getTransactions(userDetails.user());
+    public ResponseEntity<List<TempAccountBook>> trans(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<TempAccountBook> decodeList = codefService.getTransactions(userDetails.user());
 
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/main/java/dev/book/accountbook/controller/StatController.java
+++ b/src/main/java/dev/book/accountbook/controller/StatController.java
@@ -10,10 +10,7 @@ import dev.book.global.config.security.dto.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -33,8 +30,8 @@ public class StatController implements StatApi {
     }
 
     @Override
-    @GetMapping("/{frequency}/{category}")
-    public ResponseEntity<List<AccountBookSpendResponse>> categoryList(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Frequency frequency, @PathVariable String category) {
+    @GetMapping("/{frequency}")
+    public ResponseEntity<List<AccountBookSpendResponse>> categoryList(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Frequency frequency, @RequestParam String category) {
         Long userId = userDetails.user().getId();
         List<AccountBookSpendResponse> list = statService.categoryList(userId, frequency, category);
 

--- a/src/main/java/dev/book/accountbook/controller/swagger/AccountBookApi.java
+++ b/src/main/java/dev/book/accountbook/controller/swagger/AccountBookApi.java
@@ -1,10 +1,7 @@
 package dev.book.accountbook.controller.swagger;
 
 import dev.book.accountbook.dto.request.*;
-import dev.book.accountbook.dto.response.AccountBookIncomeResponse;
-import dev.book.accountbook.dto.response.AccountBookMonthResponse;
-import dev.book.accountbook.dto.response.AccountBookPeriodResponse;
-import dev.book.accountbook.dto.response.AccountBookSpendResponse;
+import dev.book.accountbook.dto.response.*;
 import dev.book.global.config.security.dto.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,7 +16,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Tag(name = "가계부 API", description = "지출 / 수입 등록, 수정, 삭제, 조회")
@@ -423,7 +422,7 @@ public interface AccountBookApi {
                     )
             )
     )
-    ResponseEntity<List<AccountBookPeriodResponse>> getAccountBookPeriod(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody AccountBookListRequest request);
+    ResponseEntity<List<AccountBookPeriodResponse>> getAccountBookPeriod(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestParam LocalDate startDate, @RequestParam LocalDate endDate);
 
     @Operation(
             summary = "지정 월 가계부 조회",
@@ -499,4 +498,43 @@ public interface AccountBookApi {
             )
     )
     ResponseEntity<List<AccountBookMonthResponse>> getMonthAccountBook(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody AccountBookMonthRequest request);
+
+    @Operation(
+            summary = "임시 지출 목록 조회",
+            description = "임시 지출 목록을 조회합니다.."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "임시 지출 목록 조회 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = TempAccountBookResponse.class)),
+                    examples = @ExampleObject(
+                            name = "임시 지출 생성 응답 예시",
+                            value = """
+                    [
+                      {
+                        "id": 1,
+                        "title": "편의점",
+                        "memo": "야식으로 컵라면",
+                        "amount": 4500,
+                        "type": "SPEND",
+                        "occurredAt": "2025-04-27",
+                        "userId": 5
+                      },
+                      {
+                        "id": 2,
+                        "title": "급여",
+                        "memo": "4월 월급",
+                        "amount": 3000000,
+                        "type": "INCOME",
+                        "occurredAt": "2025-04-25",
+                        "userId": 5
+                      }
+                    ]
+                    """
+                    )
+            )
+    )
+    ResponseEntity<List<TempAccountBookResponse>> getTempAccountBook(@AuthenticationPrincipal CustomUserDetails userDetails);
 }

--- a/src/main/java/dev/book/accountbook/controller/swagger/CodefApi.java
+++ b/src/main/java/dev/book/accountbook/controller/swagger/CodefApi.java
@@ -1,6 +1,7 @@
 package dev.book.accountbook.controller.swagger;
 
 import dev.book.accountbook.dto.request.CreateConnectedIdRequest;
+import dev.book.accountbook.entity.TempAccountBook;
 import dev.book.global.config.security.dto.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -8,6 +9,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
 
 @Tag(name = "Codef API", description = "connectedId 생성, 거래 내역 조회")
 public interface CodefApi {
@@ -33,5 +36,5 @@ public interface CodefApi {
             description = "이 API는 내부 테스트용입니다. 호출하지 마세요."
     )
     @ApiResponse(description = "호출 금지")
-    ResponseEntity<String> trans(@AuthenticationPrincipal CustomUserDetails userDetails);
+    ResponseEntity<List<TempAccountBook>> trans(@AuthenticationPrincipal CustomUserDetails userDetails);
 }

--- a/src/main/java/dev/book/accountbook/dto/event/CreateTransEvent.java
+++ b/src/main/java/dev/book/accountbook/dto/event/CreateTransEvent.java
@@ -1,0 +1,6 @@
+package dev.book.accountbook.dto.event;
+
+import dev.book.user.entity.UserEntity;
+
+public record CreateTransEvent(UserEntity user) {
+}

--- a/src/main/java/dev/book/accountbook/dto/response/TempAccountBookResponse.java
+++ b/src/main/java/dev/book/accountbook/dto/response/TempAccountBookResponse.java
@@ -1,0 +1,21 @@
+package dev.book.accountbook.dto.response;
+
+import dev.book.accountbook.entity.TempAccountBook;
+import dev.book.accountbook.type.CategoryType;
+
+import java.time.LocalDate;
+
+public record TempAccountBookResponse(Long id, String title, String memo, int amount,
+                                      CategoryType type, LocalDate occurredAt, Long userId) {
+    public static TempAccountBookResponse from(TempAccountBook entity) {
+        return new TempAccountBookResponse(
+                entity.getId(),
+                entity.getTitle(),
+                entity.getMemo(),
+                entity.getAmount(),
+                entity.getType(),
+                entity.getOccurredAt(),
+                entity.getUser().getId()
+        );
+    }
+}

--- a/src/main/java/dev/book/accountbook/entity/TempAccountBook.java
+++ b/src/main/java/dev/book/accountbook/entity/TempAccountBook.java
@@ -1,0 +1,43 @@
+package dev.book.accountbook.entity;
+
+import dev.book.accountbook.type.CategoryType;
+import dev.book.user.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class TempAccountBook {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String memo;
+    private int amount;
+
+    @Enumerated(value = EnumType.STRING)
+    private CategoryType type;
+
+    private LocalDate occurredAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+    public TempAccountBook(String title, String memo, int amount, CategoryType type, UserEntity user, LocalDate occurredAt) {
+        this.title = title;
+        this.memo = memo;
+        this.amount = amount;
+        this.type = type;
+        this.user = user;
+        this.occurredAt = occurredAt;
+    }
+}

--- a/src/main/java/dev/book/accountbook/repository/AccountBookRepository.java
+++ b/src/main/java/dev/book/accountbook/repository/AccountBookRepository.java
@@ -6,6 +6,7 @@ import dev.book.accountbook.entity.AccountBook;
 import dev.book.accountbook.type.CategoryType;
 import dev.book.challenge.rank.dto.response.RankResponse;
 import dev.book.global.entity.Category;
+import dev.book.user.entity.UserEntity;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,7 +15,6 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -39,11 +39,9 @@ public interface AccountBookRepository extends JpaRepository<AccountBook, Long> 
             @Param("endDate") LocalDate endDate
     );
 
-    @EntityGraph(attributePaths = {"category"})
     @Query("""
             SELECT a
             FROM AccountBook a
-                JOIN a.category c
                 WHERE a.user.id = :userId
                     AND a.occurredAt BETWEEN :startDate AND :endDate
                 ORDER BY a.occurredAt DESC
@@ -178,4 +176,6 @@ public interface AccountBookRepository extends JpaRepository<AccountBook, Long> 
                                     @Param("startDate") LocalDate startDate,
                                     @Param("endDate") LocalDate endDate
     );
+
+    void deleteAllByUser(UserEntity user);
 }

--- a/src/main/java/dev/book/accountbook/repository/CodefRepository.java
+++ b/src/main/java/dev/book/accountbook/repository/CodefRepository.java
@@ -3,9 +3,14 @@ package dev.book.accountbook.repository;
 import dev.book.accountbook.entity.Codef;
 import dev.book.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CodefRepository extends JpaRepository<Codef, Long> {
     Optional<Codef> findByUser(UserEntity user);
+
+    @Query("SELECT c FROM Codef c JOIN c.user u WHERE FUNCTION('DATE', u.createdAt) < CURRENT_DATE")
+    List<Codef> findAllCodefWithUserCreatedBeforeToday();
 }

--- a/src/main/java/dev/book/accountbook/repository/TempAccountBookRepository.java
+++ b/src/main/java/dev/book/accountbook/repository/TempAccountBookRepository.java
@@ -1,0 +1,10 @@
+package dev.book.accountbook.repository;
+
+import dev.book.accountbook.entity.TempAccountBook;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TempAccountBookRepository extends JpaRepository<TempAccountBook, Long> {
+    List<TempAccountBook> findByUserId(Long userId);
+}

--- a/src/main/java/dev/book/accountbook/scheduler/AccountBookScheduler.java
+++ b/src/main/java/dev/book/accountbook/scheduler/AccountBookScheduler.java
@@ -4,6 +4,7 @@ import dev.book.accountbook.dto.event.CreateTransEvent;
 import dev.book.accountbook.dto.response.AccountBookWeekConsumePerUserResponse;
 import dev.book.accountbook.entity.Budget;
 import dev.book.accountbook.entity.Codef;
+import dev.book.accountbook.entity.TempAccountBook;
 import dev.book.accountbook.repository.AccountBookRepository;
 import dev.book.accountbook.repository.BudgetRepository;
 import dev.book.accountbook.repository.CodefRepository;
@@ -80,8 +81,11 @@ public class AccountBookScheduler {
         List<Codef> codefList = codefRepository.findAllCodefWithUserCreatedBeforeToday();
 
         for (Codef codef : codefList) {
-            tempAccountBookRepository.saveAll(codefService.getTransactions(codef.getUser()));
-            eventPublisher.publishEvent(new CreateTransEvent(codef.getUser()));
+            List<TempAccountBook> savedList = tempAccountBookRepository.saveAll(codefService.getTransactions(codef.getUser()));
+
+            if (!savedList.isEmpty()) {
+                eventPublisher.publishEvent(new CreateTransEvent(codef.getUser()));
+            }
         }
     }
 

--- a/src/main/java/dev/book/accountbook/scheduler/AccountBookScheduler.java
+++ b/src/main/java/dev/book/accountbook/scheduler/AccountBookScheduler.java
@@ -1,9 +1,14 @@
 package dev.book.accountbook.scheduler;
 
+import dev.book.accountbook.dto.event.CreateTransEvent;
 import dev.book.accountbook.dto.response.AccountBookWeekConsumePerUserResponse;
 import dev.book.accountbook.entity.Budget;
+import dev.book.accountbook.entity.Codef;
 import dev.book.accountbook.repository.AccountBookRepository;
 import dev.book.accountbook.repository.BudgetRepository;
+import dev.book.accountbook.repository.CodefRepository;
+import dev.book.accountbook.repository.TempAccountBookRepository;
+import dev.book.accountbook.service.CodefService;
 import dev.book.accountbook.service.StatService;
 import dev.book.accountbook.type.Frequency;
 import dev.book.accountbook.type.PeriodRange;
@@ -24,10 +29,12 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class AccountBookScheduler {
-
+    private final CodefRepository codefRepository;
     private final BudgetRepository budgetRepository;
     private final AccountBookRepository accountBookRepository;
+    private final TempAccountBookRepository tempAccountBookRepository;
 
+    private final CodefService codefService;
     private final StatService statService;
     private final IndividualAchievementStatusService individualAchievementStatusService;
     private final ApplicationEventPublisher eventPublisher;
@@ -36,7 +43,7 @@ public class AccountBookScheduler {
 
     @Scheduled(cron = "0 0 0 1 * *", zone = "Asia/Seoul") //매월 1일마다 예산 계획 성공 여부
     @Transactional
-    public void checkBudgetSuccessfulOrNot(){
+    public void checkBudgetSuccessfulOrNot() {
         int lastMonth = LocalDate.now().minusMonths(1).getMonth().getValue();
         //저번 달 예산 계획을 세운 사람들
         List<Budget> budgets = budgetRepository.findAllByMonthWithUser(lastMonth);
@@ -49,9 +56,9 @@ public class AccountBookScheduler {
     }
 
     private void getLastMonthBudgetAndCheckSuccessUser(List<Budget> budgets) {
-        for (Budget budget : budgets){
+        for (Budget budget : budgets) {
             int lastMonthBudget = statService.getTotalConsumeOfLastMonth(budget.getUser().getId());
-            if (lastMonthBudget < budget.getBudgetLimit()){
+            if (lastMonthBudget < budget.getBudgetLimit()) {
                 // 저번 달 예산 계획과 비교하여 % 이상 절약한 사람들에게 업적 달성
                 calcSavedRateAndAchieveBudget(budget.getUser(), budget.getBudgetLimit(), lastMonthBudget);
             }
@@ -69,13 +76,18 @@ public class AccountBookScheduler {
     }
 
     @Scheduled(cron = "0 0 21 * * *")
-    public void synchronizeAccount(){
+    public void synchronizeAccount() {
+        List<Codef> codefList = codefRepository.findAllCodefWithUserCreatedBeforeToday();
 
+        for (Codef codef : codefList) {
+            tempAccountBookRepository.saveAll(codefService.getTransactions(codef.getUser()));
+            eventPublisher.publishEvent(new CreateTransEvent(codef.getUser()));
+        }
     }
 
     @Scheduled(cron = "0 0 0 * * MON", zone = "Asia/Seoul") //매주 월요일마다 주의 소비내역 비교
     @Transactional
-    public void checkConsumeOfWeekEveryMonday(){
+    public void checkConsumeOfWeekEveryMonday() {
         PeriodRange periodRange = Frequency.LAST_WEEKLY.calcPeriod();
         //저번주 일주일, 저저번주의 일주일의 소비 내역을 가져와서 비교
         List<AccountBookWeekConsumePerUserResponse> accountBooks = accountBookRepository.findUserAndAmountByConsumeOfWeek(periodRange.currentStart(), periodRange.currentEnd(), periodRange.previousStart(), periodRange.previousEnd());
@@ -85,9 +97,9 @@ public class AccountBookScheduler {
     private void calcSavedRateAndAchieveWeek(UserEntity user, long lastWeekAmount, long twoWeeksAgoAmount) {
         if (twoWeeksAgoAmount > 0 && lastWeekAmount > 0) {
             double savedRate = ((double) (twoWeeksAgoAmount - lastWeekAmount) / twoWeeksAgoAmount) * 100;
+
             if (savedRate >= LIMIT_SAVE_RATE)
                 eventPublisher.publishEvent(new SaveConsumeOfWeekEvent(user, savedRate));
         }
     }
-
 }

--- a/src/main/java/dev/book/accountbook/service/CodefService.java
+++ b/src/main/java/dev/book/accountbook/service/CodefService.java
@@ -1,12 +1,17 @@
 package dev.book.accountbook.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.book.accountbook.dto.event.CreateTransEvent;
 import dev.book.accountbook.dto.request.CreateConnectedIdRequest;
 import dev.book.accountbook.entity.Codef;
+import dev.book.accountbook.entity.TempAccountBook;
 import dev.book.accountbook.exception.codef.CodefErrorCode;
 import dev.book.accountbook.exception.codef.CodefErrorException;
 import dev.book.accountbook.repository.CodefRepository;
+import dev.book.accountbook.repository.TempAccountBookRepository;
+import dev.book.accountbook.type.CategoryType;
 import dev.book.global.util.RsaEncryptUtil;
 import dev.book.user.entity.UserEntity;
 import dev.book.user.exception.UserErrorCode;
@@ -14,6 +19,7 @@ import dev.book.user.exception.UserErrorException;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.codec.binary.Base64;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -22,6 +28,7 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,10 +49,12 @@ public class CodefService {
     private final String transactions = "https://development.codef.io/v1/kr/bank/p/account/transaction-list";
 
     private final CodefRepository codefRepository;
+    private final TempAccountBookRepository tempAccountBookRepository;
 
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
     private final RsaEncryptUtil rsaEncryptUtil;
+    private final ApplicationEventPublisher publisher;
 
     public String getAccessToken() {
         try {
@@ -79,17 +88,20 @@ public class CodefService {
         }
 
         validationCode(code);
-
         codefRepository.save(createRequest.toEntity(user, createRequest.bank().getCode(), createRequest.accountNumber(), connectedId));
+        tempAccountBookRepository.saveAll(getTransactions(user));
+
+        publisher.publishEvent(new CreateTransEvent(user));
 
         return true;
     }
 
-    public String getTransactions(UserEntity user) {
+    public List<TempAccountBook> getTransactions(UserEntity user) {
         HttpEntity<Map<String, Object>> request = createTransRequest(user);
         ResponseEntity<String> response = restTemplate.postForEntity(transactions, request, String.class);
+        String decodeResponse = URLDecoder.decode(response.getBody(), StandardCharsets.UTF_8);
 
-        return URLDecoder.decode(response.getBody(), StandardCharsets.UTF_8);
+        return mapToAccountBooks(decodeResponse, user);
     }
 
     private HttpEntity<String> getTokenRequest() {
@@ -138,19 +150,68 @@ public class CodefService {
         body.put("organization", codef.getBankCode());
         body.put("connectedId", codef.getConnectedId());
         body.put("account", codef.getAccount());
+        body.put("orderBy", "0");
+
+        if (user.getCreatedAt().toLocalDate().isEqual(LocalDate.now())) {
+            String startDate = LocalDate.now().minusDays(90)
+                    .format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+            body.put("startDate", startDate);
+            body.put("endDate", today);
+
+            return new HttpEntity<>(body, headers);
+        }
+
         body.put("startDate", today);
         body.put("endDate", today);
-        body.put("orderBy", "0");
 
         return new HttpEntity<>(body, headers);
     }
 
     private void validationCode(String code) {
         switch (code) {
-            case "CF-00000" -> {}
+            case "CF-00000" -> {
+            }
             case "CF-12801", "CF-12803" -> throw new CodefErrorException(CodefErrorCode.INVALID_LOGIN_INFO);
             case "CF-12802" -> throw new CodefErrorException(CodefErrorCode.PASSWORD_ERROR_COUNT_EXCEEDED);
             default -> throw new CodefErrorException(CodefErrorCode.UNKNOWN_ERROR, code);
         }
+    }
+
+    private List<TempAccountBook> mapToAccountBooks(String jsonString, UserEntity user) {
+        JsonNode root = null;
+
+        try {
+            root = objectMapper.readTree(jsonString);
+        } catch (Exception e) {
+            throw new CodefErrorException(CodefErrorCode.UNKNOWN_ERROR);
+        }
+
+        JsonNode resTrHistoryList = root.path("data").path("resTrHistoryList");
+
+        List<TempAccountBook> accountBooks = new ArrayList<>();
+
+        for (JsonNode transaction : resTrHistoryList) {
+            String title = transaction.path("resAccountDesc2").asText();
+            String desc3 = transaction.path("resAccountDesc3").asText();
+            String desc4 = transaction.path("resAccountDesc4").asText();
+            String memo = desc3 + "_" + desc4;
+
+            int resAccountOut = transaction.path("resAccountOut").asInt();
+            int resAccountIn = transaction.path("resAccountIn").asInt();
+
+            boolean isIncome = resAccountIn > 0;
+            int amount = isIncome ? resAccountIn : resAccountOut;
+            CategoryType type = isIncome ? CategoryType.INCOME : CategoryType.SPEND;
+
+            String resAccountTrDate = transaction.path("resAccountTrDate").asText();
+            LocalDate occurredAt = LocalDate.parse(resAccountTrDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+            TempAccountBook accountBook = new TempAccountBook(title, memo, amount, type, user, occurredAt);
+
+            accountBooks.add(accountBook);
+        }
+
+        return accountBooks;
     }
 }

--- a/src/main/java/dev/book/accountbook/service/CodefService.java
+++ b/src/main/java/dev/book/accountbook/service/CodefService.java
@@ -62,7 +62,8 @@ public class CodefService {
             ResponseEntity<String> response = restTemplate.postForEntity(TOKEN_URL, entity, String.class);
 
             if (response.getStatusCode() == HttpStatus.OK) {
-                HashMap<String, Object> responseMap = objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+                HashMap<String, Object> responseMap = objectMapper.readValue(response.getBody(), new TypeReference<>() {
+                });
 
                 return (String) responseMap.get("access_token");
             } else {
@@ -89,9 +90,11 @@ public class CodefService {
 
         validationCode(code);
         codefRepository.save(createRequest.toEntity(user, createRequest.bank().getCode(), createRequest.accountNumber(), connectedId));
-        tempAccountBookRepository.saveAll(getTransactions(user));
+        List<TempAccountBook> savedList = tempAccountBookRepository.saveAll(getTransactions(user));
 
-        publisher.publishEvent(new CreateTransEvent(user));
+        if (!savedList.isEmpty()) {
+            publisher.publishEvent(new CreateTransEvent(user));
+        }
 
         return true;
     }

--- a/src/test/java/dev/book/accountbook/service/BudgetServiceUnitTest.java
+++ b/src/test/java/dev/book/accountbook/service/BudgetServiceUnitTest.java
@@ -86,10 +86,10 @@ class BudgetServiceUnitTest {
     void getBudget() {
         // given
         Long budgetId = 1L;
-        UserEntity user = mock(UserEntity.class);
-        Budget budget = new Budget(10000, 4, user);
-        BudgetResponse budgetResponse = new BudgetResponse(budgetId, 10000, 4);
         int month = LocalDate.now().getMonthValue();
+        UserEntity user = mock(UserEntity.class);
+        Budget budget = new Budget(10000, month, user);
+        BudgetResponse budgetResponse = new BudgetResponse(budgetId, 10000, 4);
 
         given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(budgetRepository.findByIdAndMonthAndUserId(budgetId, month, user.getId())).willReturn(Optional.of(budget));


### PR DESCRIPTION
## 설명
매일 계정 거래내역 동시화 하도록 구현

## 이슈 번호
 Resolves: #76 

## PR 유형
- 당일 가입한 유저를 제외한 유저 매일 21시 거래내역 가져오도록 구현
- 당일 가입한 유저는 90일치 거래내역 들고오도록 구현
- 거래내역 임시 테이블 저장
- 거래내역 임시 테이블에 저장 완료 후 FCM을 이용해 알림 전송
